### PR TITLE
menu/ignore tooltips 36

### DIFF
--- a/Menu/MenuUtils.h
+++ b/Menu/MenuUtils.h
@@ -16,8 +16,9 @@
 + (NSString *)getApplicationNameForWindow:(unsigned long)windowId;
 + (BOOL)isWindowValid:(unsigned long)windowId;
 + (BOOL)isWindowMapped:(unsigned long)windowId;
++ (BOOL)isWindowSkippableAsActive:(unsigned long)windowId;
 + (BOOL)isDesktopWindow:(unsigned long)windowId;
-+ (NSArray *)getAllWindows;
++ (NSArray *)getAllWindows; 
 + (unsigned long)getActiveWindow;
 + (NSString *)getWindowProperty:(unsigned long)windowId atomName:(NSString *)atomName;
 + (NSString*)getWindowMenuService:(unsigned long)windowId;

--- a/Menu/MenuUtils.m
+++ b/Menu/MenuUtils.m
@@ -422,8 +422,81 @@ static Display *_sharedDisplay = NULL;
     return desktopWindow;
 }
 
-+ (pid_t)getWindowPID:(unsigned long)windowId
++ (BOOL)isWindowSkippableAsActive:(unsigned long)windowId
 {
+    if (windowId == 0) return YES;
+
+    Display *display = [self openDisplay];
+    if (!display) return NO;
+
+    // Get window attributes
+    XWindowAttributes attrs;
+    if (XGetWindowAttributes(display, (Window)windowId, &attrs) == 0) {
+        // Can't get attrs; be conservative and treat as not skippable
+        return NO;
+    }
+
+    // Skip override-redirect windows (tooltips, menus from toolkits often set this)
+    if (attrs.override_redirect) {
+        NSLog(@"MenuUtils: Window %lu has override_redirect - skipping as active", windowId);
+        return YES;
+    }
+
+    // Check _MOTIF_WM_HINTS decorations flag (decorations == 0 => undecorated)
+    Atom motifAtom = XInternAtom(display, "_MOTIF_WM_HINTS", False);
+    if (motifAtom != None) {
+        Atom actualType; int actualFormat; unsigned long nitems, bytesAfter;
+        unsigned char *prop = NULL;
+        if (XGetWindowProperty(display, (Window)windowId, motifAtom,
+                              0, 5, False, XA_CARDINAL,
+                              &actualType, &actualFormat, &nitems, &bytesAfter,
+                              &prop) == Success && prop) {
+            long *hints = (long *)prop;
+            if (nitems >= 3) {
+                long decorations = hints[2];
+                if (decorations == 0) {
+                    XFree(prop);
+                    NSLog(@"MenuUtils: Window %lu has no decorations (_MOTIF_WM_HINTS) - skipping as active", windowId);
+                    return YES;
+                }
+            }
+            XFree(prop);
+        }
+    }
+
+    // Check _NET_WM_WINDOW_TYPE for tooltip/popup/menu/notification
+    Atom windowTypeAtom = XInternAtom(display, "_NET_WM_WINDOW_TYPE", False);
+    Atom tooltipAtom = XInternAtom(display, "_NET_WM_WINDOW_TYPE_TOOLTIP", False);
+    Atom popupAtom = XInternAtom(display, "_NET_WM_WINDOW_TYPE_POPUP_MENU", False);
+    Atom dropdownAtom = XInternAtom(display, "_NET_WM_WINDOW_TYPE_DROPDOWN_MENU", False);
+    Atom notifAtom = XInternAtom(display, "_NET_WM_WINDOW_TYPE_NOTIFICATION", False);
+    Atom menuAtom = XInternAtom(display, "_NET_WM_WINDOW_TYPE_MENU", False);
+
+    if (windowTypeAtom != None) {
+        Atom actualType; int actualFormat; unsigned long nitems, bytesAfter;
+        unsigned char *prop = NULL;
+        if (XGetWindowProperty(display, (Window)windowId, windowTypeAtom,
+                              0, (~0L), False, XA_ATOM,
+                              &actualType, &actualFormat, &nitems, &bytesAfter,
+                              &prop) == Success && prop) {
+            Atom *types = (Atom *)prop;
+            for (unsigned long i = 0; i < nitems; i++) {
+                if (types[i] == tooltipAtom || types[i] == popupAtom || types[i] == dropdownAtom || types[i] == notifAtom || types[i] == menuAtom) {
+                    XFree(prop);
+                    NSLog(@"MenuUtils: Window %lu has skippable _NET_WM_WINDOW_TYPE - skipping as active", windowId);
+                    return YES;
+                }
+            }
+            XFree(prop);
+        }
+    }
+
+    [self closeDisplay:display];
+    return NO;
+}
+
++ (pid_t)getWindowPID:(unsigned long)windowId
+{ 
     if (windowId == 0) return 0;
 
     Display *display = [self openDisplay];
@@ -446,8 +519,13 @@ static Display *_sharedDisplay = NULL;
                           &actualType, &actualFormat, &nitems, &bytesAfter,
                           &prop) == Success && prop) {
         if (nitems >= 1) {
-            unsigned long val = *((unsigned long *)prop);
-            pid = (pid_t)val;
+            if (actualFormat == 32) {
+                pid = (pid_t)(*(uint32_t *)prop);
+            } else if (actualFormat == 16) {
+                pid = (pid_t)(*(uint16_t *)prop);
+            } else if (actualFormat == 8) {
+                pid = (pid_t)(*(uint8_t *)prop);
+            }
         }
         XFree(prop);
     }

--- a/Menu/MenuUtils.m
+++ b/Menu/MenuUtils.m
@@ -429,8 +429,6 @@ static Display *_sharedDisplay = NULL;
     Display *display = [self openDisplay];
     if (!display) return NO;
 
-    BOOL shouldSkip = NO;
-
     // Get window attributes
     XWindowAttributes attrs;
     if (XGetWindowAttributes(display, (Window)windowId, &attrs) == 0) {
@@ -498,7 +496,7 @@ static Display *_sharedDisplay = NULL;
     }
 
     [self closeDisplay:display];
-    return shouldSkip;
+    return NO;
 }
 
 + (pid_t)getWindowPID:(unsigned long)windowId

--- a/Menu/MenuUtils.m
+++ b/Menu/MenuUtils.m
@@ -429,16 +429,20 @@ static Display *_sharedDisplay = NULL;
     Display *display = [self openDisplay];
     if (!display) return NO;
 
+    BOOL shouldSkip = NO;
+
     // Get window attributes
     XWindowAttributes attrs;
     if (XGetWindowAttributes(display, (Window)windowId, &attrs) == 0) {
         // Can't get attrs; be conservative and treat as not skippable
+        [self closeDisplay:display];
         return NO;
     }
 
     // Skip override-redirect windows (tooltips, menus from toolkits often set this)
     if (attrs.override_redirect) {
         NSLog(@"MenuUtils: Window %lu has override_redirect - skipping as active", windowId);
+        [self closeDisplay:display];
         return YES;
     }
 
@@ -457,6 +461,7 @@ static Display *_sharedDisplay = NULL;
                 if (decorations == 0) {
                     XFree(prop);
                     NSLog(@"MenuUtils: Window %lu has no decorations (_MOTIF_WM_HINTS) - skipping as active", windowId);
+                    [self closeDisplay:display];
                     return YES;
                 }
             }
@@ -484,6 +489,7 @@ static Display *_sharedDisplay = NULL;
                 if (types[i] == tooltipAtom || types[i] == popupAtom || types[i] == dropdownAtom || types[i] == notifAtom || types[i] == menuAtom) {
                     XFree(prop);
                     NSLog(@"MenuUtils: Window %lu has skippable _NET_WM_WINDOW_TYPE - skipping as active", windowId);
+                    [self closeDisplay:display];
                     return YES;
                 }
             }
@@ -492,7 +498,7 @@ static Display *_sharedDisplay = NULL;
     }
 
     [self closeDisplay:display];
-    return NO;
+    return shouldSkip;
 }
 
 + (pid_t)getWindowPID:(unsigned long)windowId

--- a/Menu/WindowMonitor.m
+++ b/Menu/WindowMonitor.m
@@ -203,6 +203,12 @@ NSString * const WindowMonitorActiveWindowChangedNotification = @"WindowMonitorA
         } else if (!canGetAttrs) {
             NSLog(@"WindowMonitor: Cannot get attributes for initial window %lu - trusting WM", newActiveWindow);
         }
+
+        // Ignore tooltips, popup menus, and undecorated override_redirect windows as active
+        if (newActiveWindow != 0 && [MenuUtils isWindowSkippableAsActive:newActiveWindow]) {
+            NSLog(@"WindowMonitor: Initial active window %lu is skippable (tooltip/popup/override) - ignoring", newActiveWindow);
+            newActiveWindow = _currentActiveWindow;
+        }
         
         if (newActiveWindow != 0) {
             XSelectInput(_display, (Window)newActiveWindow, StructureNotifyMask | PropertyChangeMask);
@@ -255,6 +261,12 @@ NSString * const WindowMonitorActiveWindowChangedNotification = @"WindowMonitorA
             // Only ignore if we get a BadWindow error, otherwise keep it
             // For now, trust the window manager's report
             NSLog(@"WindowMonitor: Cannot get attributes for active window %lu - trusting WM report anyway", newActiveWindow);
+        }
+
+        // Ignore tooltips, popup menus, and undecorated override_redirect windows as active
+        if (newActiveWindow != 0 && [MenuUtils isWindowSkippableAsActive:newActiveWindow]) {
+            NSLog(@"WindowMonitor: Active window %lu is skippable (tooltip/popup/override) - ignoring", newActiveWindow);
+            newActiveWindow = _currentActiveWindow;
         }
         
         // Select for events on this window if we can

--- a/Menu/WindowMonitor.m
+++ b/Menu/WindowMonitor.m
@@ -196,16 +196,15 @@ NSString * const WindowMonitorActiveWindowChangedNotification = @"WindowMonitorA
             if (affected != 0 && [MenuUtils isWindowSkippableAsActive:affected]) {
                 NSLog(@"WindowMonitor: Skippable window %lu destroyed/unmapped - flagging to suppress next PropertyNotify", affected);
                 _lastSkippableWindow = affected;
-                continue;
-            }
-            
-            // Clear the flag if a non-skippable window event occurs
-            _lastSkippableWindow = 0;
-            
-            if (affected != 0 && affected == _currentActiveWindow) {
-                // Window that was active is now gone - check what the new active window is
-                NSLog(@"WindowMonitor: Active window %lu destroyed/unmapped - checking for new active window", affected);
-                [self checkActiveWindow];
+            } else {
+                // Clear the flag if a non-skippable window event occurs
+                _lastSkippableWindow = 0;
+                
+                if (affected != 0 && affected == _currentActiveWindow) {
+                    // Window that was active is now gone - check what the new active window is
+                    NSLog(@"WindowMonitor: Active window %lu destroyed/unmapped - checking for new active window", affected);
+                    [self checkActiveWindow];
+                }
             }
         }
     }

--- a/Menu/WindowMonitor.m
+++ b/Menu/WindowMonitor.m
@@ -22,6 +22,7 @@
     dispatch_source_t _x11EventSource;
     dispatch_queue_t _x11Queue;
     unsigned long _currentActiveWindow;
+    unsigned long _lastSkippableWindow;
     BOOL _monitoring;
 }
 - (void)_postWindowNotification:(NSDictionary *)userInfo;
@@ -59,6 +60,7 @@ NSString * const WindowMonitorActiveWindowChangedNotification = @"WindowMonitorA
         _gstepAppAtom = 0;
         _x11EventSource = NULL;
         _currentActiveWindow = 0;
+        _lastSkippableWindow = 0;
         _monitoring = NO;
         
         // Create serial queue for X11 operations
@@ -162,9 +164,44 @@ NSString * const WindowMonitorActiveWindowChangedNotification = @"WindowMonitorA
             event.xproperty.window == _rootWindow &&
             event.xproperty.atom == _netActiveWindowAtom) {
             
+            // Check if this PropertyNotify is right after a skippable window unmap
+            // Read what the WM says is active now
+            Atom actualType;
+            int actualFormat;
+            unsigned long nitems, bytesAfter;
+            unsigned char *prop = NULL;
+            unsigned long wmActiveWindow = 0;
+            
+            if (XGetWindowProperty(_display, _rootWindow, _netActiveWindowAtom,
+                                  0, 1, False, XA_WINDOW,
+                                  &actualType, &actualFormat, &nitems, &bytesAfter,
+                                  &prop) == 0 && prop) {
+                wmActiveWindow = *(Window*)prop;
+                XFree(prop);
+            }
+            
+            // If the WM is now reporting 0 or a skippable window, and we just saw a skippable window unmap,
+            // suppress this check to avoid clearing the menu
+            if ((wmActiveWindow == 0 || [MenuUtils isWindowSkippableAsActive:wmActiveWindow]) && _lastSkippableWindow != 0) {
+                NSLog(@"WindowMonitor: PropertyNotify for _NET_ACTIVE_WINDOW after skippable window unmap - suppressing to avoid menu interference (WM reports: %lu)", wmActiveWindow);
+                _lastSkippableWindow = 0; // Clear the flag
+                continue;
+            }
+            
             [self checkActiveWindow];
         } else if (event.type == DestroyNotify || event.type == UnmapNotify) {
             Window affected = (event.type == DestroyNotify) ? event.xdestroywindow.window : event.xunmap.window;
+            
+            // Check if this is a skippable window being destroyed/unmapped
+            if (affected != 0 && [MenuUtils isWindowSkippableAsActive:affected]) {
+                NSLog(@"WindowMonitor: Skippable window %lu destroyed/unmapped - flagging to suppress next PropertyNotify", affected);
+                _lastSkippableWindow = affected;
+                continue;
+            }
+            
+            // Clear the flag if a non-skippable window event occurs
+            _lastSkippableWindow = 0;
+            
             if (affected != 0 && affected == _currentActiveWindow) {
                 // Window that was active is now gone - check what the new active window is
                 NSLog(@"WindowMonitor: Active window %lu destroyed/unmapped - checking for new active window", affected);
@@ -207,6 +244,7 @@ NSString * const WindowMonitorActiveWindowChangedNotification = @"WindowMonitorA
         // Ignore tooltips, popup menus, and undecorated override_redirect windows as active
         if (newActiveWindow != 0 && [MenuUtils isWindowSkippableAsActive:newActiveWindow]) {
             NSLog(@"WindowMonitor: Initial active window %lu is skippable (tooltip/popup/override) - ignoring", newActiveWindow);
+            _lastSkippableWindow = newActiveWindow; // Track this for later unmap suppression
             newActiveWindow = _currentActiveWindow;
         }
         
@@ -266,6 +304,7 @@ NSString * const WindowMonitorActiveWindowChangedNotification = @"WindowMonitorA
         // Ignore tooltips, popup menus, and undecorated override_redirect windows as active
         if (newActiveWindow != 0 && [MenuUtils isWindowSkippableAsActive:newActiveWindow]) {
             NSLog(@"WindowMonitor: Active window %lu is skippable (tooltip/popup/override) - ignoring", newActiveWindow);
+            _lastSkippableWindow = newActiveWindow; // Track this for later unmap suppression
             newActiveWindow = _currentActiveWindow;
         }
         

--- a/UIBridge/Server/main.m
+++ b/UIBridge/Server/main.m
@@ -515,6 +515,8 @@ static void RedirectLogs(void) {
             @"tools": @[
                 @{@"name": @"launch_app", @"description": @"Launches a GNUstep application. The application will automatically register its UIBridge service via Distributed Objects if it uses the Eau theme.", @"inputSchema": @{@"type": @"object", @"properties": @{@"app_path": @{@"type": @"string", @"description": @"The absolute path to the .app bundle or its binary executable."}}}, @"outputSchema": contentSchema},
                 @{@"name": @"list_apps", @"description": @"Scans standard GNUstep application directories and returns a list of installed applications. Use this to discover which apps are available to be launched and tested on the current system.", @"inputSchema": @{@"type": @"object", @"properties": @{}}, @"outputSchema": contentSchema},
+                @{@"name": @"list_running_apps", @"description": @"Scans running processes for GNUstep applications that have registered an Eau theme UIBridge service via Distributed Objects and returns their PID, service name, and optional metadata (app name, preview). Use this to discover already-launched apps to attach to.", @"inputSchema": @{@"type": @"object", @"properties": @{}}, @"outputSchema": contentSchema},
+                @{@"name": @"attach_app", @"description": @"Attach UIBridge to an already-running GNUstep application by PID or service name. Provide either 'pid' (integer) or 'service_name' (string). On success the server's currentPID is set to the attached app's PID.", @"inputSchema": @{@"type": @"object", @"properties": @{@"pid": @{@"type": @"integer"}, @"service_name": @{@"type": @"string"}}}, @"outputSchema": contentSchema},
                 @{@"name": @"list_files", @"description": @"Lists files in a given directory path. Useful for exploring application resources, data bundles, or confirming the presence of specifically required files before or during testing.", @"inputSchema": @{@"type": @"object", @"properties": @{@"path": @{@"type": @"string", @"description": @"The directory path to list."}}}, @"outputSchema": contentSchema},
                 @{@"name": @"read_file_content", @"description": @"Reads the full text content of a file. Use this to inspect configuration files, logs, or other text-based data within the application's environment.", @"inputSchema": @{@"type": @"object", @"properties": @{@"path": @{@"type": @"string", @"description": @"The path to the file to read."}}}, @"outputSchema": contentSchema},
                 @{@"name": @"get_root", @"description": @"Retrieves the entry-level Objective-C objects for the currently running app: the NSApp instance and a list of all top-level windows. This provides the starting point for exploring the UI widget tree and application-wide state.", @"inputSchema": @{@"type": @"object", @"properties": @{}}, @"outputSchema": contentSchema},
@@ -642,7 +644,7 @@ static void RedirectLogs(void) {
                     result = @{
                         @"pid": @(self.currentPID), 
                         @"status": @"launched",
-                        @"observation": @"Application launched. The UIBridge server will automatically attempt to connect via Distributed Objects (DO) in the background. You can monitor progress via logs or wait for 'notifications/ui_event'."
+                        @"observation": @"Application launched. You can monitor progress via logs in /tmp or wait for 'notifications/ui_event'."
                     };
                 } else {
                      errorMsg = @"Failed to launch";
@@ -687,6 +689,107 @@ static void RedirectLogs(void) {
                 }
             }
             result = @{@"apps": apps};
+        } else if ([toolName isEqualToString:@"list_running_apps"]) {
+            NSMutableArray *found = [NSMutableArray array];
+            NSTask *psTask = [[NSTask alloc] init];
+            [psTask setLaunchPath:@"/bin/ps"];
+            [psTask setArguments:@[@"-axo", @"pid="]];
+            NSPipe *pipe = [NSPipe pipe];
+            [psTask setStandardOutput:pipe];
+            [psTask setStandardError:[NSFileHandle fileHandleWithNullDevice]];
+            @try {
+                [psTask launch];
+                [psTask waitUntilExit];
+            } @catch (NSException *e) {
+                NSLog(@"[Server] Failed to run ps for list_running_apps: %@", e);
+                [psTask release];
+                result = @{@"apps": found};
+            }
+
+            NSData *psData = [[pipe fileHandleForReading] readDataToEndOfFile];
+            [psTask release];
+
+            NSString *psOutput = [[NSString alloc] initWithData:psData encoding:NSUTF8StringEncoding];
+            NSArray *lines = [psOutput componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+            [psOutput release];
+
+            for (NSString *line in lines) {
+                NSString *entry = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+                if ([entry length] == 0) continue;
+                NSCharacterSet *digits = [NSCharacterSet decimalDigitCharacterSet];
+                if ([entry rangeOfCharacterFromSet:[digits invertedSet]].location != NSNotFound) continue;
+
+                NSString *themeServiceName = [NSString stringWithFormat:@"org.gershwin.Gershwin.Theme.UIBridge.%@", entry];
+                id proxy = [NSConnection rootProxyForConnectionWithRegisteredName:themeServiceName host:nil];
+                if (proxy) {
+                    [(NSDistantObject *)proxy setProtocolForProxy:@protocol(UIBridgeProtocol)];
+                    NSConnection *conn = [proxy connectionForProxy];
+                    [conn setRequestTimeout:1.0];
+                    [conn setReplyTimeout:1.0];
+                    [conn enableMultipleThreads];
+
+                    NSMutableDictionary *info = [NSMutableDictionary dictionary];
+                    info[@"pid"] = @([entry intValue]);
+                    info[@"service"] = themeServiceName;
+
+                    NSString *commPath = [NSString stringWithFormat:@"/proc/%@/comm", entry];
+                    NSError *err = nil;
+                    NSString *comm = [NSString stringWithContentsOfFile:commPath encoding:NSUTF8StringEncoding error:&err];
+                    if (comm) info[@"comm"] = [comm stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+
+                    @try {
+                        NSString *rootJSON = [proxy rootObjectsJSON];
+                        if ([rootJSON length] > 0) {
+                            NSString *preview = [rootJSON substringToIndex:MIN((NSUInteger)256, [rootJSON length])];
+                            info[@"preview"] = preview;
+                        }
+                    } @catch (NSException *e) {
+                        // ignore failures to query the app; service presence is enough
+                    }
+
+                    [found addObject:info];
+                }
+            }
+
+            result = @{@"apps": found};
+        } else if ([toolName isEqualToString:@"attach_app"]) {
+            NSNumber *pidNum = callParams[@"pid"];
+            NSString *service = callParams[@"service_name"];
+            id proxy = nil;
+            int pid = 0;
+            if (service) {
+                proxy = [NSConnection rootProxyForConnectionWithRegisteredName:service host:nil];
+                if (proxy) {
+                    [(NSDistantObject *)proxy setProtocolForProxy:@protocol(UIBridgeProtocol)];
+                    NSConnection *conn = [proxy connectionForProxy];
+                    [conn setRequestTimeout:2.0];
+                    [conn setReplyTimeout:2.0];
+                    [conn enableMultipleThreads];
+                    // try a light probe
+                    @try {
+                        [proxy rootObjectsJSON];
+                    } @catch (NSException *e) {
+                        proxy = nil;
+                    }
+                    // attempt to extract PID from service name if formatted with trailing PID
+                    if (proxy && pid == 0) {
+                        NSCharacterSet *nonDigits = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
+                        NSString *digits = [[service componentsSeparatedByCharactersInSet:nonDigits] componentsJoinedByString:@""];
+                        if ([digits length] > 0) pid = [digits intValue];
+                    }
+                }
+            } else if (pidNum) {
+                pid = [pidNum intValue];
+                proxy = ConnectToApp(pid);
+            } else {
+                errorMsg = @"Missing pid or service_name";
+            }
+            if (proxy) {
+                self.currentPID = pid;
+                result = @{@"status": @"attached", @"pid": @(self.currentPID), @"service": service ?: [NSString stringWithFormat:@"org.gershwin.Gershwin.Theme.UIBridge.%d", self.currentPID]};
+            } else {
+                errorMsg = @"Failed to attach to service/pid";
+            }
         } else if ([toolName isEqualToString:@"list_files"]) {
             NSString *path = callParams[@"path"];
             if (!path) path = @".";

--- a/UIBridge/Server/main.m
+++ b/UIBridge/Server/main.m
@@ -692,67 +692,72 @@ static void RedirectLogs(void) {
         } else if ([toolName isEqualToString:@"list_running_apps"]) {
             NSMutableArray *found = [NSMutableArray array];
             NSTask *psTask = [[NSTask alloc] init];
-            [psTask setLaunchPath:@"/bin/ps"];
-            [psTask setArguments:@[@"-axo", @"pid="]];
+            [psTask setLaunchPath:@"/usr/bin/env"];
+            [psTask setArguments:@[@"ps", @"-axo", @"pid="]];
             NSPipe *pipe = [NSPipe pipe];
             [psTask setStandardOutput:pipe];
             [psTask setStandardError:[NSFileHandle fileHandleWithNullDevice]];
+            
+            BOOL didRun = NO;
             @try {
                 [psTask launch];
                 [psTask waitUntilExit];
+                didRun = YES;
             } @catch (NSException *e) {
                 NSLog(@"[Server] Failed to run ps for list_running_apps: %@", e);
+            } @finally {
                 [psTask release];
+            }
+
+            if (!didRun) {
                 result = @{@"apps": found};
-            }
+            } else {
+                NSData *psData = [[pipe fileHandleForReading] readDataToEndOfFile];
 
-            NSData *psData = [[pipe fileHandleForReading] readDataToEndOfFile];
-            [psTask release];
+                NSString *psOutput = [[NSString alloc] initWithData:psData encoding:NSUTF8StringEncoding];
+                NSArray *lines = [psOutput componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+                [psOutput release];
 
-            NSString *psOutput = [[NSString alloc] initWithData:psData encoding:NSUTF8StringEncoding];
-            NSArray *lines = [psOutput componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
-            [psOutput release];
+                for (NSString *line in lines) {
+                    NSString *entry = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+                    if ([entry length] == 0) continue;
+                    NSCharacterSet *digits = [NSCharacterSet decimalDigitCharacterSet];
+                    if ([entry rangeOfCharacterFromSet:[digits invertedSet]].location != NSNotFound) continue;
 
-            for (NSString *line in lines) {
-                NSString *entry = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-                if ([entry length] == 0) continue;
-                NSCharacterSet *digits = [NSCharacterSet decimalDigitCharacterSet];
-                if ([entry rangeOfCharacterFromSet:[digits invertedSet]].location != NSNotFound) continue;
+                    NSString *themeServiceName = [NSString stringWithFormat:@"org.gershwin.Gershwin.Theme.UIBridge.%@", entry];
+                    id proxy = [NSConnection rootProxyForConnectionWithRegisteredName:themeServiceName host:nil];
+                    if (proxy) {
+                        [(NSDistantObject *)proxy setProtocolForProxy:@protocol(UIBridgeProtocol)];
+                        NSConnection *conn = [proxy connectionForProxy];
+                        [conn setRequestTimeout:1.0];
+                        [conn setReplyTimeout:1.0];
+                        [conn enableMultipleThreads];
 
-                NSString *themeServiceName = [NSString stringWithFormat:@"org.gershwin.Gershwin.Theme.UIBridge.%@", entry];
-                id proxy = [NSConnection rootProxyForConnectionWithRegisteredName:themeServiceName host:nil];
-                if (proxy) {
-                    [(NSDistantObject *)proxy setProtocolForProxy:@protocol(UIBridgeProtocol)];
-                    NSConnection *conn = [proxy connectionForProxy];
-                    [conn setRequestTimeout:1.0];
-                    [conn setReplyTimeout:1.0];
-                    [conn enableMultipleThreads];
+                        NSMutableDictionary *info = [NSMutableDictionary dictionary];
+                        info[@"pid"] = @([entry intValue]);
+                        info[@"service"] = themeServiceName;
 
-                    NSMutableDictionary *info = [NSMutableDictionary dictionary];
-                    info[@"pid"] = @([entry intValue]);
-                    info[@"service"] = themeServiceName;
+                        NSString *commPath = [NSString stringWithFormat:@"/proc/%@/comm", entry];
+                        NSError *err = nil;
+                        NSString *comm = [NSString stringWithContentsOfFile:commPath encoding:NSUTF8StringEncoding error:&err];
+                        if (comm) info[@"comm"] = [comm stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 
-                    NSString *commPath = [NSString stringWithFormat:@"/proc/%@/comm", entry];
-                    NSError *err = nil;
-                    NSString *comm = [NSString stringWithContentsOfFile:commPath encoding:NSUTF8StringEncoding error:&err];
-                    if (comm) info[@"comm"] = [comm stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-
-                    @try {
-                        NSString *rootJSON = [proxy rootObjectsJSON];
-                        if ([rootJSON length] > 0) {
-                            NSString *preview = [rootJSON substringToIndex:MIN((NSUInteger)256, [rootJSON length])];
-                            info[@"preview"] = preview;
+                        @try {
+                            NSString *rootJSON = [proxy rootObjectsJSON];
+                            if ([rootJSON length] > 0) {
+                                NSString *preview = [rootJSON substringToIndex:MIN((NSUInteger)256, [rootJSON length])];
+                                info[@"preview"] = preview;
+                            }
+                        } @catch (NSException *e) {
+                            // ignore failures to query the app; service presence is enough
                         }
-                    } @catch (NSException *e) {
-                        // ignore failures to query the app; service presence is enough
+
+                        [found addObject:info];
                     }
-
-                    [found addObject:info];
                 }
-            }
 
-            result = @{@"apps": found};
-        } else if ([toolName isEqualToString:@"attach_app"]) {
+                result = @{@"apps": found};
+            } else if ([toolName isEqualToString:@"attach_app"]) {
             NSNumber *pidNum = callParams[@"pid"];
             NSString *service = callParams[@"service_name"];
             id proxy = nil;


### PR DESCRIPTION
Reproduction steps:
1. Open Workspace Filer from dock.
2. Hover Terminal icon until its tooltip shows.
3. Move pointer to next dock icon — menu blanks when the tooltip becomes active.

Hypothesis: transient tooltip/popup windows are being treated as the active window. WindowMonitor should ignore windows without decorations or with _NET_WM_WINDOW_TYPE of TOOLTIP/POPUP/DROPDOWN/MENU/NOTIFICATION.

his change adds MenuUtils::isWindowSkippableAsActive() and updates WindowMonitor to ignore such windows when deciding the active window.

Closes/refs: #36

Can you try this branch and report whether it fixes the issue?