### PR TITLE
UIBridge: make synthetic input drive GNUstep apps (XSendEvent + activation, error handling, keyboard)

### DIFF
--- a/UIBridge/Server/GNUmakefile
+++ b/UIBridge/Server/GNUmakefile
@@ -1,7 +1,21 @@
 include $(GNUSTEP_MAKEFILES)/common.make
 
 TOOL_NAME = UIBridgeServer
-ADDITIONAL_LDFLAGS += -Wl,-rpath,/usr/lib/aarch64-linux-gnu:/lib/aarch64-linux-gnu -lX11 -lXext
+
+# X11 input automation needs only core Xlib (synthetic input via XSendEvent, plus
+# the XKB client API which lives in libX11). Discover the compiler/linker flags
+# with pkg-config so this builds unchanged on both Linux and FreeBSD (where the
+# X11 headers and libraries live under /usr/local). Fall back to a plain -l flag
+# if pkg-config is unavailable.
+X11_PKGS := x11
+X11_CFLAGS := $(shell pkg-config --cflags $(X11_PKGS) 2>/dev/null)
+X11_LIBS := $(shell pkg-config --libs $(X11_PKGS) 2>/dev/null)
+ifeq ($(strip $(X11_LIBS)),)
+X11_LIBS := -lX11
+endif
+
+ADDITIONAL_INCLUDE_DIRS += $(X11_CFLAGS)
+ADDITIONAL_LDFLAGS += $(X11_LIBS)
 UIBridgeServer_OBJC_FILES = main.m X11Support.m LLDBController.m
 UIBridgeServer_LIBRARIES = gnustep-base gnustep-gui objc
 

--- a/UIBridge/Server/X11Support.h
+++ b/UIBridge/Server/X11Support.h
@@ -22,4 +22,11 @@
 // windows.
 + (void)activateWindow:(unsigned long)xid;
 
+// Send a single key with zero or more modifiers held (e.g. Control+c, or just
+// Return) — for shortcuts and menu accelerators that plain text typing cannot
+// express. Modifier names: "control"/"ctrl", "alt"/"meta", "shift",
+// "super"/"win". The key is either a single character or an X keysym name such
+// as "Return", "Left" or "F5".
++ (void)simulateChordWithModifiers:(NSArray *)modifiers key:(NSString *)key;
+
 @end

--- a/UIBridge/Server/X11Support.h
+++ b/UIBridge/Server/X11Support.h
@@ -17,4 +17,9 @@
 + (void)simulateClick:(int)button; // 1=left, 2=middle, 3=right
 + (void)simulateKeyStroke:(NSString *)keyString;
 
+// Raise + focus a window so subsequent keyboard input is delivered to it rather
+// than an occluding window. Needed because the desktop usually has overlapping
+// windows.
++ (void)activateWindow:(unsigned long)xid;
+
 @end

--- a/UIBridge/Server/X11Support.m
+++ b/UIBridge/Server/X11Support.m
@@ -28,6 +28,12 @@ static Display *display = NULL;
 // and release are not coalesced into a single zero-duration event.
 static const useconds_t kPressHoldMicroseconds = 40000;  // 40 ms
 
+// When typing a character by temporarily rebinding a spare keycode (the Unicode
+// path), how long to let the keyboard-mapping change (MappingNotify) reach the
+// target client before pressing the key, and to let it decode the press before
+// we revert.
+static const useconds_t kRemapSettleMicroseconds = 30000;  // 30 ms
+
 // Xlib's default error handler calls exit() on any protocol error, which would
 // take down this long-running automation server. A few codes are expected
 // during automation — e.g. a BadWindow/BadDrawable/BadMatch from racing a window
@@ -361,6 +367,54 @@ static KeySym KeysymForChar(unichar c) {
     return NoSymbol;
 }
 
+// Type an arbitrary Unicode scalar that has no key on the active layout by
+// temporarily binding it to an unused keycode, sending a press/release addressed
+// to the target window, then restoring that keycode — the technique xdotool uses
+// for general text. GNUstep refreshes its keymap on the MappingNotify our remap
+// triggers (XGServerEvent.m:1499), then decodes the synthetic press to the bound
+// codepoint. X maps a codepoint to the keysym 0x01000000 + codepoint.
+static void TypeUnicodeScalar(Display *d, Window target, uint32_t scalar, Time *t) {
+    int minKc = 0, maxKc = 0;
+    XDisplayKeycodes(d, &minKc, &maxKc);
+    int per = 0;
+    KeySym *map = XGetKeyboardMapping(d, minKc, maxKc - minKc + 1, &per);
+    if (!map || per <= 0) { if (map) XFree(map); return; }
+
+    // Find a keycode whose every level is unbound, searching from the top of the
+    // range where spares usually live.
+    int spare = 0;
+    for (int kc = maxKc; kc >= minKc && spare == 0; kc--) {
+        Bool unbound = True;
+        for (int l = 0; l < per; l++) {
+            if (map[(kc - minKc) * per + l] != NoSymbol) { unbound = False; break; }
+        }
+        if (unbound) spare = kc;
+    }
+    if (spare == 0) {
+        NSDebugLLog(@"gwcomp", @"[X11Support] no spare keycode to type U+%04X", scalar);
+        XFree(map);
+        return;
+    }
+
+    // X keysym for the scalar: codepoints U+0000..U+00FF are their own keysym
+    // (Latin-1); U+0100 and above use the 0x01000000 direct-Unicode encoding.
+    KeySym uni = (scalar <= 0xff) ? (KeySym)scalar : (0x01000000 | scalar);
+    KeySym bind[2] = { uni, uni };  // levels 0 and 1 both map to the scalar
+    XChangeKeyboardMapping(d, spare, 2, bind, 1);
+    XSync(d, False);
+    usleep(kRemapSettleMicroseconds);   // let the target client refresh its keymap
+
+    SendKey(d, target, (KeyCode)spare, True, 0, *t); (*t)++;
+    SendKey(d, target, (KeyCode)spare, False, 0, *t); (*t)++;
+    XSync(d, False);
+    usleep(kRemapSettleMicroseconds);   // let it decode the press before we revert
+
+    // Restore the keycode's original (unbound) mapping.
+    XChangeKeyboardMapping(d, spare, per, &map[(spare - minKc) * per], 1);
+    XSync(d, False);
+    XFree(map);
+}
+
 + (void)simulateKeyStroke:(NSString *)keyString {
     Display *d = [self display];
     if (!d) return;
@@ -381,10 +435,10 @@ static KeySym KeysymForChar(unichar c) {
             }
         }
 
-        // Characters that exist on the active layout are typed directly. When the
-        // character sits on the keycode's shifted level, set ShiftMask in the
-        // event's state so GNUstep's character lookup picks the shifted symbol
-        // (so 'A', '!', '?', ':' come out right, not their unshifted twin).
+        // Fast path: characters that exist on the active layout are typed
+        // directly. When the character sits on the keycode's shifted level, set
+        // ShiftMask in the event's state so GNUstep's character lookup picks the
+        // shifted symbol (so 'A', '!', '?', ':' come out right, not their twin).
         KeySym sym = (scalar <= 0xffff) ? KeysymForChar((unichar)scalar) : NoSymbol;
         KeyCode code = (sym != NoSymbol) ? XKeysymToKeycode(d, sym) : 0;
         if (code != 0) {
@@ -397,9 +451,91 @@ static KeySym KeysymForChar(unichar c) {
             continue;
         }
 
-        // Characters with no key on the active layout (accented Latin, CJK, emoji)
-        // are not expressible by keycode and are skipped here.
-        NSDebugLLog(@"gwcomp", @"[X11Support] no layout key for character U+%04X", scalar);
+        // Slow path: any other scalar (accented Latin not on this layout, CJK,
+        // emoji) via a temporary keymap remap.
+        TypeUnicodeScalar(d, target, scalar, &t);
+    }
+    XSync(d, False);
+}
+
+// Map a modifier name to its left-hand keysym; NoSymbol if unrecognised.
+static KeySym ModifierKeysym(NSString *name) {
+    NSString *m = [name lowercaseString];
+    if ([m isEqualToString:@"control"] || [m isEqualToString:@"ctrl"]) return XK_Control_L;
+    if ([m isEqualToString:@"alt"] || [m isEqualToString:@"meta"]) return XK_Alt_L;
+    if ([m isEqualToString:@"shift"]) return XK_Shift_L;
+    if ([m isEqualToString:@"super"] || [m isEqualToString:@"win"]) return XK_Super_L;
+    return NoSymbol;
+}
+
+// The X modifier-mask bit (ShiftMask, ControlMask, Mod1Mask…) bound to a modifier
+// keysym, by scanning the modifier map; 0 if unbound. Used so a chord's character
+// is looked up at the right shift level (GNUstep's character lookup honours the
+// event state, even though its *modifier flags* come from tracked key presses).
+static unsigned int ModMaskForKeysym(Display *d, KeySym sym) {
+    KeyCode target = XKeysymToKeycode(d, sym);
+    if (target == 0) return 0;
+    XModifierKeymap *mm = XGetModifierMapping(d);
+    if (!mm) return 0;
+    unsigned int mask = 0;
+    for (int i = 0; i < 8 && mask == 0; i++) {
+        for (int j = 0; j < mm->max_keypermod; j++) {
+            if (mm->modifiermap[i * mm->max_keypermod + j] == target) {
+                mask = (1u << i);
+                break;
+            }
+        }
+    }
+    XFreeModifiermap(mm);
+    return mask;
+}
+
+// Resolve a chord key string to a keysym: a single character via KeysymForChar,
+// otherwise an X keysym name ("Return", "Left", "F5", "Tab").
+static KeySym ChordKeysym(NSString *key) {
+    if ([key length] == 1) {
+        KeySym s = KeysymForChar([key characterAtIndex:0]);
+        if (s != NoSymbol) return s;
+    }
+    return XStringToKeysym([key UTF8String]);
+}
+
++ (void)simulateChordWithModifiers:(NSArray *)modifiers key:(NSString *)key {
+    Display *d = [self display];
+    if (!d) return;
+
+    KeySym ksym = ChordKeysym(key);
+    if (ksym == NoSymbol) {
+        NSDebugLLog(@"gwcomp", @"[X11Support] unknown chord key '%@'", key);
+        return;
+    }
+    KeyCode code = XKeysymToKeycode(d, ksym);
+    if (code == 0) return;
+
+    Window target = ResolveKeyTarget(d);
+    if (target == None) return;
+    Time t = ServerTime(d);
+
+    // Press the modifiers (so GNUstep tracks them and reports the right modifier
+    // flags), accumulating their state mask so the key's character is looked up at
+    // the correct shift level; tap the key; release the modifiers in reverse.
+    KeyCode held[8];
+    unsigned int state = 0;
+    NSUInteger n = 0;
+    for (id name in modifiers) {
+        if (n >= 8 || ![name isKindOfClass:[NSString class]]) continue;
+        KeySym ms = ModifierKeysym(name);
+        if (ms == NoSymbol) continue;
+        KeyCode mc = XKeysymToKeycode(d, ms);
+        if (mc == 0) continue;
+        state |= ModMaskForKeysym(d, ms);
+        held[n++] = mc;
+        SendKey(d, target, mc, True, 0, t); t++;
+    }
+    SendKey(d, target, code, True, state, t); t++;
+    SendKey(d, target, code, False, state, t); t++;
+    for (NSUInteger i = n; i > 0; i--) {
+        SendKey(d, target, held[i - 1], False, 0, t); t++;
     }
     XSync(d, False);
 }

--- a/UIBridge/Server/X11Support.m
+++ b/UIBridge/Server/X11Support.m
@@ -8,10 +8,25 @@
 #import <X11/Xlib.h>
 #import <X11/Xatom.h>
 #import <X11/keysym.h>
+// Synthetic input is injected with XSendEvent. GNUstep's X backend does not
+// filter synthetic events; the reason naive XSendEvent appears to do nothing is
+// that the event must name the GNUstep content window (the one carrying
+// _GNUSTEP_WM_ATTR), not the window-manager frame that reparents it — the backend
+// looks the target up in its own window table (XGServerEvent.m). We therefore
+// resolve the GNUstep window under the pointer (for clicks) or holding input
+// focus (for keys) and address the event to it. XKB is used to find the shift
+// level for a character's keysym. This input path is X11-only; a Wayland session
+// would need a different backend.
+#import <X11/XKBlib.h>
+#include <unistd.h>
 
 @implementation X11Support
 
 static Display *display = NULL;
+
+// How long to hold a synthetic button press before releasing it, so the press
+// and release are not coalesced into a single zero-duration event.
+static const useconds_t kPressHoldMicroseconds = 40000;  // 40 ms
 
 + (Display *)display {
     if (!display) {
@@ -33,34 +48,34 @@ static Display *display = NULL;
 + (NSArray *)windowList {
     Display *d = [self display];
     if (!d) return @[];
-    
+
     Window root = DefaultRootWindow(d);
     Window parent;
     Window *children = NULL;
     unsigned int nchildren = 0;
-    
+
     NSMutableArray *result = [NSMutableArray array];
-    
+
     if (XQueryTree(d, root, &root, &parent, &children, &nchildren)) {
         for (unsigned int i = 0; i < nchildren; i++) {
             [result addObject:@(children[i])];
         }
         if (children) XFree(children);
     }
-    
+
     return result;
 }
 
 + (NSDictionary *)windowInfo:(unsigned long)xid {
     Display *d = [self display];
     if (!d) return nil;
-    
+
     Window w = (Window)xid;
     XWindowAttributes attrs;
     if (!XGetWindowAttributes(d, w, &attrs)) {
         return nil;
     }
-    
+
     // Get Property: _NET_WM_NAME or WM_NAME
     NSString *title = @"";
     char *name = NULL;
@@ -68,7 +83,7 @@ static Display *display = NULL;
         title = [NSString stringWithUTF8String:name];
         XFree(name);
     }
-    
+
     // Get PID: _NET_WM_PID
     unsigned long pid = 0;
     Atom atomPID = XInternAtom(d, "_NET_WM_PID", True);
@@ -86,7 +101,7 @@ static Display *display = NULL;
             }
         }
     }
-    
+
     return @{
         @"id": @(w),
         @"x": @(attrs.x),
@@ -99,99 +114,234 @@ static Display *display = NULL;
     };
 }
 
+// True if the window carries _GNUSTEP_WM_ATTR. GNUstep sets this on every content
+// window it creates, unconditionally (XGServerWindow.m), so it is the reliable
+// marker of "a window the GNUstep backend will recognise" — unlike _NET_WM_PID,
+// which is only set under an EWMH window manager and is also copied onto the frame.
+static Bool HasGNUstepAttr(Display *d, Window w) {
+    static Atom attr = None;
+    if (attr == None) attr = XInternAtom(d, "_GNUSTEP_WM_ATTR", False);
+    Atom type; int fmt; unsigned long n, after; unsigned char *data = NULL;
+    if (XGetWindowProperty(d, w, attr, 0, 1, False, AnyPropertyType,
+                           &type, &fmt, &n, &after, &data) != Success)
+        return False;
+    Bool has = (type != None);
+    if (data) XFree(data);
+    return has;
+}
+
+// Resolve the GNUstep content window under root point (x,y) and the point in that
+// window's coordinates. Descends from root with XTranslateCoordinates to the
+// deepest window under the point, remembering the deepest one bearing
+// _GNUSTEP_WM_ATTR (the actual GNUstep window, not the reparenting WM frame).
+// Falls back to the leaf window if none qualifies (bare server / non-GNUstep app).
+static Window ResolveWindowAt(Display *d, int x, int y, int *outX, int *outY) {
+    Window root = DefaultRootWindow(d);
+    Window cur = root, chosen = None;
+    int curX = x, curY = y, chX = x, chY = y;
+    for (;;) {
+        Window child = None;
+        int dx = 0, dy = 0;
+        if (!XTranslateCoordinates(d, root, cur, x, y, &dx, &dy, &child))
+            break;
+        curX = dx; curY = dy;                 // point in cur's coordinates
+        if (cur != root && HasGNUstepAttr(d, cur)) {
+            chosen = cur; chX = curX; chY = curY;
+        }
+        if (child == None) break;
+        cur = child;
+    }
+    if (chosen == None) { chosen = cur; chX = curX; chY = curY; }
+    *outX = chX; *outY = chY;
+    return chosen;
+}
+
+// First GNUstep content window at or below w (depth first), or None.
+static Window FindGNUstepWindowBelow(Display *d, Window w) {
+    if (HasGNUstepAttr(d, w)) return w;
+    Window root, parent, *kids = NULL;
+    unsigned int n = 0;
+    Window found = None;
+    if (XQueryTree(d, w, &root, &parent, &kids, &n)) {
+        for (unsigned int i = 0; i < n && found == None; i++)
+            found = FindGNUstepWindowBelow(d, kids[i]);
+        if (kids) XFree(kids);
+    }
+    return found;
+}
+
+// The GNUstep window that should receive keyboard input. X delivers a key event
+// to the client owning the addressed window, and GNUstep then routes it to its
+// own key window (XGServerEvent.m:2231) — so the event must be addressed to a
+// GNUstep-owned window, or the app's process never sees it. Prefer the input-focus
+// window (set by activateWindow), descending into it for the GNUstep child when
+// the frame itself holds focus; fall back to the window under the pointer.
+static Window ResolveKeyTarget(Display *d) {
+    Window focus = None;
+    int revert = 0;
+    XGetInputFocus(d, &focus, &revert);
+    if (focus != None && focus != PointerRoot) {
+        Window w = FindGNUstepWindowBelow(d, focus);
+        if (w != None) return w;
+    }
+    Window root = DefaultRootWindow(d), r, child;
+    int rx = 0, ry = 0, wx = 0, wy = 0;
+    unsigned int mask = 0;
+    if (XQueryPointer(d, root, &r, &child, &rx, &ry, &wx, &wy, &mask)) {
+        int ox, oy;
+        Window w = ResolveWindowAt(d, rx, ry, &ox, &oy);
+        if (w != None) return w;
+    }
+    return focus;
+}
+
+// A real X server timestamp. GNUstep compares successive click times to detect
+// multi-clicks (XGServerEvent.m:433); CurrentTime (0) would make every click look
+// like a first click, so we round-trip a zero-length property append on a private
+// window and read the timestamp the server stamps on the resulting PropertyNotify.
+static Bool MatchTimestamp(Display *d, XEvent *e, XPointer arg) {
+    return (e->type == PropertyNotify && e->xproperty.atom == *(Atom *)arg) ? True : False;
+}
+static Time ServerTime(Display *d) {
+    static Window win = None;
+    static Atom atom = None;
+    if (win == None) {
+        win = XCreateWindow(d, DefaultRootWindow(d), -10, -10, 1, 1, 0,
+                            CopyFromParent, InputOnly, CopyFromParent, 0, NULL);
+        XSelectInput(d, win, PropertyChangeMask);
+        atom = XInternAtom(d, "_UIBRIDGE_TIMESTAMP", False);
+    }
+    XChangeProperty(d, win, atom, XA_CARDINAL, 8, PropModeAppend,
+                    (unsigned char *)"", 0);
+    XEvent e;
+    XIfEvent(d, &e, MatchTimestamp, (XPointer)&atom);
+    return e.xproperty.time;
+}
+
+static void SendButton(Display *d, Window w, int wx, int wy, int rx, int ry,
+                       Bool press, unsigned int button, unsigned int state, Time t) {
+    XEvent e;
+    memset(&e, 0, sizeof(e));
+    e.type = press ? ButtonPress : ButtonRelease;
+    e.xbutton.send_event = True;
+    e.xbutton.display = d;
+    e.xbutton.window = w;
+    e.xbutton.root = DefaultRootWindow(d);
+    e.xbutton.subwindow = None;
+    e.xbutton.time = t;
+    e.xbutton.x = wx; e.xbutton.y = wy;
+    e.xbutton.x_root = rx; e.xbutton.y_root = ry;
+    e.xbutton.state = state;
+    e.xbutton.button = button;
+    e.xbutton.same_screen = True;
+    XSendEvent(d, w, True, press ? ButtonPressMask : ButtonReleaseMask, &e);
+}
+
+static void SendKey(Display *d, Window w, KeyCode code,
+                    Bool press, unsigned int state, Time t) {
+    XEvent e;
+    memset(&e, 0, sizeof(e));
+    e.type = press ? KeyPress : KeyRelease;
+    e.xkey.send_event = True;
+    e.xkey.display = d;
+    e.xkey.window = w;
+    e.xkey.root = DefaultRootWindow(d);
+    e.xkey.subwindow = None;
+    e.xkey.time = t;
+    e.xkey.x = 1; e.xkey.y = 1;
+    e.xkey.x_root = 0; e.xkey.y_root = 0;
+    e.xkey.state = state;
+    e.xkey.keycode = code;
+    e.xkey.same_screen = True;
+    XSendEvent(d, w, True, press ? KeyPressMask : KeyReleaseMask, &e);
+}
+
 + (void)simulateMouseMoveTo:(NSPoint)point {
     Display *d = [self display];
     if (!d) return;
-    
+    // Move the real pointer so callers can position the cursor (hover) and so a
+    // subsequent click resolves the window under this location. Assumes screen 0.
     Window root = DefaultRootWindow(d);
     XWarpPointer(d, None, root, 0, 0, 0, 0, (int)point.x, (int)point.y);
-    XFlush(d);
-}
-
-static void SendButtonEvent(Display *d, int button, Bool press) {
-    Window root = DefaultRootWindow(d);
-    Window child = None;
-    int root_x, root_y, win_x, win_y;
-    unsigned int mask;
-    
-    // Get current pointer position
-    XQueryPointer(d, root, &root, &child, &root_x, &root_y, &win_x, &win_y, &mask);
-    
-    // Target window is child if exists, else root
-    Window target = (child != None) ? child : root;
-    
-    XEvent event;
-    memset(&event, 0, sizeof(event));
-    
-    event.type = press ? ButtonPress : ButtonRelease;
-    event.xbutton.button = button;
-    event.xbutton.same_screen = True;
-    event.xbutton.subwindow = None; // Should probably be child if we targeted root?
-    event.xbutton.window = target;
-    event.xbutton.root = root;
-    event.xbutton.x_root = root_x;
-    event.xbutton.y_root = root_y;
-    event.xbutton.x = (child != None) ? win_x : root_x;
-    event.xbutton.y = (child != None) ? win_y : root_y;
-    event.xbutton.time = CurrentTime;
-    
-    XSendEvent(d, target, True, ButtonPressMask | ButtonReleaseMask, &event);
-    XFlush(d);
+    XSync(d, False);
 }
 
 + (void)simulateClick:(int)button {
     Display *d = [self display];
     if (!d) return;
-    
-    SendButtonEvent(d, button, True); // Press
-    SendButtonEvent(d, button, False); // Release
+    Window root = DefaultRootWindow(d), r, child;
+    int rx = 0, ry = 0, wx = 0, wy = 0;
+    unsigned int mask = 0;
+    if (!XQueryPointer(d, root, &r, &child, &rx, &ry, &wx, &wy, &mask)) return;
+
+    int tx, ty;
+    Window target = ResolveWindowAt(d, rx, ry, &tx, &ty);
+    Time t = ServerTime(d);
+    unsigned int bmask = (button == 1) ? Button1Mask :
+                         (button == 2) ? Button2Mask :
+                         (button == 3) ? Button3Mask : 0;
+    SendButton(d, target, tx, ty, rx, ry, True, (unsigned int)button, 0, t);
+    XFlush(d);
+    usleep(kPressHoldMicroseconds);  // hold so press/release aren't coalesced
+    SendButton(d, target, tx, ty, rx, ry, False, (unsigned int)button, bmask, t + 1);
+    XSync(d, False);
 }
 
-static void SendKeyEvent(Display *d, KeyCode keycode, Bool press) {
-    Window root = DefaultRootWindow(d);
-    Window focus;
-    int revert;
-    XGetInputFocus(d, &focus, &revert);
-    
-    if (focus == None) focus = root;
-    
-    XEvent event;
-    memset(&event, 0, sizeof(event));
-    
-    event.type = press ? KeyPress : KeyRelease;
-    event.xkey.keycode = keycode;
-    event.xkey.window = focus;
-    event.xkey.root = root;
-    event.xkey.same_screen = True;
-    event.xkey.time = CurrentTime;
-    
-    XSendEvent(d, focus, True, KeyPressMask | KeyReleaseMask, &event);
-    XFlush(d);
+// The keysym for a control char or, for printable ASCII/Latin-1, the codepoint
+// itself (those keysyms equal the Unicode value). Returns NoSymbol if the
+// character has no single keysym this way (e.g. emoji / CJK).
+static KeySym KeysymForChar(unichar c) {
+    switch (c) {
+        case '\n': case '\r': return XK_Return;
+        case '\t': return XK_Tab;
+        case 0x1b: return XK_Escape;
+        case 0x08: case 0x7f: return XK_BackSpace;
+    }
+    if (c >= 0x20 && c <= 0xff) return (KeySym)c;
+    return NoSymbol;
 }
 
 + (void)simulateKeyStroke:(NSString *)keyString {
     Display *d = [self display];
     if (!d) return;
-    
-    for (NSUInteger i = 0; i < [keyString length]; i++) {
+    Window target = ResolveKeyTarget(d);
+    if (target == None) return;
+
+    Time t = ServerTime(d);
+    NSUInteger len = [keyString length];
+    for (NSUInteger i = 0; i < len; i++) {
         unichar c = [keyString characterAtIndex:i];
-        KeySym sym = NoSymbol;
-        
-        if (c >= 'a' && c <= 'z') sym = XK_a + (c - 'a');
-        else if (c >= 'A' && c <= 'Z') sym = XK_A + (c - 'A');
-        else if (c >= '0' && c <= '9') sym = XK_0 + (c - '0');
-        else if (c == ' ') sym = XK_space;
-        else if (c == '\n') sym = XK_Return;
-        else if (c == '\t') sym = XK_Tab;
-        
-        if (sym != NoSymbol) {
-             KeyCode code = XKeysymToKeycode(d, sym);
-             if (code != 0) {
-                 SendKeyEvent(d, code, True);
-                 SendKeyEvent(d, code, False);
-             }
+        uint32_t scalar = c;
+        // Combine a UTF-16 surrogate pair into one Unicode scalar (e.g. emoji).
+        if (c >= 0xd800 && c <= 0xdbff && i + 1 < len) {
+            unichar lo = [keyString characterAtIndex:i + 1];
+            if (lo >= 0xdc00 && lo <= 0xdfff) {
+                scalar = 0x10000 + (((uint32_t)c - 0xd800) << 10) + ((uint32_t)lo - 0xdc00);
+                i++;
+            }
         }
+
+        // Characters that exist on the active layout are typed directly. When the
+        // character sits on the keycode's shifted level, set ShiftMask in the
+        // event's state so GNUstep's character lookup picks the shifted symbol
+        // (so 'A', '!', '?', ':' come out right, not their unshifted twin).
+        KeySym sym = (scalar <= 0xffff) ? KeysymForChar((unichar)scalar) : NoSymbol;
+        KeyCode code = (sym != NoSymbol) ? XKeysymToKeycode(d, sym) : 0;
+        if (code != 0) {
+            Bool needShift = (XkbKeycodeToKeysym(d, code, 0, 0) != sym &&
+                              XkbKeycodeToKeysym(d, code, 0, 1) == sym);
+            unsigned int st = needShift ? ShiftMask : 0;
+            SendKey(d, target, code, True, st, t); t++;
+            SendKey(d, target, code, False, st, t); t++;
+            XFlush(d);
+            continue;
+        }
+
+        // Characters with no key on the active layout (accented Latin, CJK, emoji)
+        // are not expressible by keycode and are skipped here.
+        NSDebugLLog(@"gwcomp", @"[X11Support] no layout key for character U+%04X", scalar);
     }
+    XSync(d, False);
 }
 
 @end

--- a/UIBridge/Server/X11Support.m
+++ b/UIBridge/Server/X11Support.m
@@ -28,8 +28,32 @@ static Display *display = NULL;
 // and release are not coalesced into a single zero-duration event.
 static const useconds_t kPressHoldMicroseconds = 40000;  // 40 ms
 
+// Xlib's default error handler calls exit() on any protocol error, which would
+// take down this long-running automation server. A few codes are expected
+// during automation — e.g. a BadWindow/BadDrawable/BadMatch from racing a window
+// that closes mid-request — and are swallowed. Anything else is logged loudly
+// but still tolerated, so genuine bugs stay visible without crashing the server.
+static int NonFatalXError(Display *dpy, XErrorEvent *e) {
+    switch (e->error_code) {
+        case BadWindow:
+        case BadDrawable:
+        case BadMatch:
+            NSDebugLLog(@"gwcomp", @"[X11Support] ignored transient X error %d (request %d)",
+                        e->error_code, e->request_code);
+            return 0;
+        default:
+            break;
+    }
+    char buf[256];
+    XGetErrorText(dpy, e->error_code, buf, sizeof(buf));
+    NSLog(@"[X11Support] X protocol error: %s (code %d, request %d) — continuing",
+          buf, e->error_code, e->request_code);
+    return 0;
+}
+
 + (Display *)display {
     if (!display) {
+        XSetErrorHandler(NonFatalXError);
         display = XOpenDisplay(NULL);
         if (!display) {
             NSDebugLLog(@"gwcomp", @"[X11Support] Failed to open X display");

--- a/UIBridge/Server/X11Support.m
+++ b/UIBridge/Server/X11Support.m
@@ -287,6 +287,42 @@ static void SendKey(Display *d, Window w, KeyCode code,
     XSync(d, False);
 }
 
++ (void)activateWindow:(unsigned long)xid {
+    Display *d = [self display];
+    if (!d || xid == 0) return;
+    Window w = (Window)xid;
+    Window root = DefaultRootWindow(d);
+
+    // Standard EWMH request: ask the window manager to activate the window.
+    // Source indication 2 ("pager") is the value WMs honour for automation; it
+    // bypasses the focus-stealing prevention that ignores an application's own
+    // (source 1) activation requests.
+    Atom netActive = XInternAtom(d, "_NET_ACTIVE_WINDOW", False);
+    XEvent e;
+    memset(&e, 0, sizeof(e));
+    e.type = ClientMessage;
+    e.xclient.window = w;
+    e.xclient.message_type = netActive;
+    e.xclient.format = 32;
+    e.xclient.data.l[0] = 2;            // source indication: pager / automation
+    e.xclient.data.l[1] = CurrentTime;
+    XSendEvent(d, root, False, SubstructureRedirectMask | SubstructureNotifyMask, &e);
+
+    // Fallback for WMs that ignore EWMH (or a bare server with no WM): raise the
+    // top-level frame (walk up to the child of root) and set input focus on the
+    // client window directly.
+    Window cur = w, parent = w, retRoot = root, *children = NULL;
+    unsigned int n = 0;
+    while (XQueryTree(d, cur, &retRoot, &parent, &children, &n)) {
+        if (children) { XFree(children); children = NULL; }
+        if (parent == retRoot || parent == 0) break;
+        cur = parent;
+    }
+    XRaiseWindow(d, cur);
+    XSetInputFocus(d, w, RevertToParent, CurrentTime);
+    XFlush(d);
+}
+
 // The keysym for a control char or, for printable ASCII/Latin-1, the codepoint
 // itself (those keysyms equal the Unicode value). Returns NoSymbol if the
 // character has no single keysym this way (e.g. emoji / CJK).

--- a/UIBridge/Server/main.m
+++ b/UIBridge/Server/main.m
@@ -537,6 +537,7 @@ static void RedirectLogs(void) {
                 @{@"name": @"x11_mouse_move", @"description": @"Moves the system mouse cursor to the specified screen coordinates. Can be combined with x11_click for raw input automation tasks.", @"inputSchema": @{@"type": @"object", @"properties": @{@"x": @{@"type": @"integer", @"description": @"The X screen coordinate."}, @"y": @{@"type": @"integer", @"description": @"The Y screen coordinate."}}}, @"outputSchema": contentSchema},
                 @{@"name": @"x11_click", @"description": @"Simulates a hardware mouse button click at the current cursor position. Works for both system-level and application-level widgets.", @"inputSchema": @{@"type": @"object", @"properties": @{@"button": @{@"type": @"integer", @"description": @"The mouse button to click: 1=Left, 2=Middle, 3=Right."}}}, @"outputSchema": contentSchema},
                 @{@"name": @"x11_type", @"description": @"Simulates typing a UTF-8 string into the currently focused window. Useful for automating text entry in fields where direct Objective-C manipulation is not desired or to test actual keyboard event handling.", @"inputSchema": @{@"type": @"object", @"properties": @{@"text": @{@"type": @"string", @"description": @"The text string to type."}}}, @"outputSchema": contentSchema},
+                @{@"name": @"x11_activate_window", @"description": @"Raises and focuses the X11 window with the given XID (EWMH _NET_ACTIVE_WINDOW plus a raise/focus fallback) so subsequent mouse/keyboard input is delivered to it rather than an occluding window.", @"inputSchema": @{@"type": @"object", @"properties": @{@"xid": @{@"type": @"integer", @"description": @"The X11 window ID to raise and focus."}}}, @"outputSchema": contentSchema},
                 // LLDB Tools
                 @{@"name": @"lldb_exec", @"description": @"Executes an arbitrary LLDB command against the target application while the debugger is attached. This provides the most powerful inspection and modification capabilities, including memory scanning, breakpoint management, and backtrace inspection. Note: this may briefly pause the application execution.", @"inputSchema": @{@"type": @"object", @"properties": @{@"command": @{@"type": @"string", @"description": @"The LLDB command to execute."}}}, @"outputSchema": contentSchema}
             ]
@@ -875,6 +876,14 @@ static void RedirectLogs(void) {
                 result = @{@"status": @"ok"};
             } else {
                 errorMsg = @"Missing text";
+            }
+        } else if ([toolName isEqualToString:@"x11_activate_window"]) {
+            NSNumber *xid = callParams[@"xid"];
+            if (xid) {
+                [X11Support activateWindow:[xid unsignedLongValue]];
+                result = @{@"status": @"ok"};
+            } else {
+                errorMsg = @"Missing xid";
             }
         } else if ([toolName isEqualToString:@"lldb_exec"]) {
             if (self.currentPID == 0) {

--- a/UIBridge/Server/main.m
+++ b/UIBridge/Server/main.m
@@ -538,6 +538,7 @@ static void RedirectLogs(void) {
                 @{@"name": @"x11_click", @"description": @"Simulates a hardware mouse button click at the current cursor position. Works for both system-level and application-level widgets.", @"inputSchema": @{@"type": @"object", @"properties": @{@"button": @{@"type": @"integer", @"description": @"The mouse button to click: 1=Left, 2=Middle, 3=Right."}}}, @"outputSchema": contentSchema},
                 @{@"name": @"x11_type", @"description": @"Simulates typing a UTF-8 string into the currently focused window. Useful for automating text entry in fields where direct Objective-C manipulation is not desired or to test actual keyboard event handling.", @"inputSchema": @{@"type": @"object", @"properties": @{@"text": @{@"type": @"string", @"description": @"The text string to type."}}}, @"outputSchema": contentSchema},
                 @{@"name": @"x11_activate_window", @"description": @"Raises and focuses the X11 window with the given XID (EWMH _NET_ACTIVE_WINDOW plus a raise/focus fallback) so subsequent mouse/keyboard input is delivered to it rather than an occluding window.", @"inputSchema": @{@"type": @"object", @"properties": @{@"xid": @{@"type": @"integer", @"description": @"The X11 window ID to raise and focus."}}}, @"outputSchema": contentSchema},
+                @{@"name": @"x11_chord", @"description": @"Sends a single key press with zero or more modifiers held (e.g. Control+c, or just Return). Use this for keyboard shortcuts and menu accelerators that x11_type (plain text) cannot express.", @"inputSchema": @{@"type": @"object", @"properties": @{@"modifiers": @{@"type": @"array", @"items": @{@"type": @"string"}, @"description": @"Modifier names to hold: control/ctrl, alt/meta, shift, super/win."}, @"key": @{@"type": @"string", @"description": @"The key: a single character (e.g. \"c\") or an X keysym name (e.g. \"Return\", \"Left\", \"F5\")."}}}, @"outputSchema": contentSchema},
                 // LLDB Tools
                 @{@"name": @"lldb_exec", @"description": @"Executes an arbitrary LLDB command against the target application while the debugger is attached. This provides the most powerful inspection and modification capabilities, including memory scanning, breakpoint management, and backtrace inspection. Note: this may briefly pause the application execution.", @"inputSchema": @{@"type": @"object", @"properties": @{@"command": @{@"type": @"string", @"description": @"The LLDB command to execute."}}}, @"outputSchema": contentSchema}
             ]
@@ -884,6 +885,16 @@ static void RedirectLogs(void) {
                 result = @{@"status": @"ok"};
             } else {
                 errorMsg = @"Missing xid";
+            }
+        } else if ([toolName isEqualToString:@"x11_chord"]) {
+            NSString *key = callParams[@"key"];
+            if (key) {
+                NSArray *mods = callParams[@"modifiers"];
+                if (![mods isKindOfClass:[NSArray class]]) mods = @[];
+                [X11Support simulateChordWithModifiers:mods key:key];
+                result = @{@"status": @"ok"};
+            } else {
+                errorMsg = @"Missing key";
             }
         } else if ([toolName isEqualToString:@"lldb_exec"]) {
             if (self.currentPID == 0) {


### PR DESCRIPTION
## What

Five focused commits to the **UIBridge** MCP server (`UIBridge/Server`) that make its
synthetic-input path actually work on GNUstep, plus a portable build and some
robustness/coverage additions:

1. **Portable X11 build flags via `pkg-config`** — replaces a hardcoded Linux-aarch64
   rpath with `pkg-config x11` (plain `-l` fallback). Synthetic input needs only core
   Xlib (`XSendEvent` + the XKB client API, both in `libX11`), so the package set is
   just `x11` — **no `libXtst`/`libXext` dependency**. Builds unchanged on Linux and
   FreeBSD (where X11 lives under `/usr/local`).
2. **Inject synthetic input via `XSendEvent` to the GNUstep content window** — the core
   fix (see *Why*).
3. **`x11_activate_window` tool** — EWMH `_NET_ACTIVE_WINDOW` (pager source indication)
   + raise/focus fallback.
4. **Non-fatal X error handler** — survive expected transient races.
5. **Modifier chords + arbitrary Unicode** — new `x11_chord`, and a Unicode-capable
   `x11_type`.

## Why

`x11_click` / `x11_type` did nothing against GNUstep apps with naive `XSendEvent`. The
usual explanation — "GNUstep filters synthetic events (`send_event=True`)" — is **wrong**.
Reading the backend (`libs-back` `XGServerEvent.m`) shows there is no `send_event` filter
on `ButtonPress`/`KeyPress`/`MotionNotify`. The real problem is **addressing**: the
backend looks the event's target window up in its own table and routes it, but the window
reported by the WM and by pointer queries is the **reparenting WM frame**, not the GNUstep
**content window** — so the lookup misses and the event is dropped.

Fixing the targeting makes plain `XSendEvent` work, needs **no GNUstep change**, and
removes the `libXtst` dependency that an earlier (XTEST-based) version of this series
carried. Around the core fix:

- **Activation** so input lands on the intended window under occlusion / with no WM.
- **Error handling** because Xlib's default handler `exit()`s the process on any protocol
  error (e.g. a `BadWindow` from racing a window that just closed), killing the server
  mid-session; now scoped to swallow only `BadWindow`/`BadDrawable`/`BadMatch` and log
  anything else loudly.
- **Keyboard coverage**: XKB shift-level handling, modifier chords (Ctrl/Alt/Shift/Super
  for shortcuts/accelerators), and arbitrary Unicode incl. surrogate-pair emoji.

## How

- **Resolve the real GNUstep window before sending.** Descend from the root with
  `XTranslateCoordinates` to the deepest window under the point that carries
  `_GNUSTEP_WM_ATTR` (the marker GNUstep sets on every content window, unlike `_NET_WM_PID`
  which is EWMH-gated and also copied onto the frame); leaf fallback for a bare server.
  Mouse buttons are addressed there in window-local coordinates.
- **Keys go to the focused GNUstep window.** X delivers a key event to the client owning
  the addressed window; GNUstep then routes it to its own key window — so the event must
  name a GNUstep-owned window. Resolve via input focus (descending into the frame for the
  GNUstep child), pointer fallback.
- **Real server timestamp** (zero-length property round-trip) so multi-click detection
  works; `CurrentTime` would make every click look like a first click. Shifted characters
  set `ShiftMask` in the event state.
- **Chords** press the modifiers as real key events (GNUstep derives its modifier flags
  from tracked modifier presses, not the event state mask) and also set the state mask so
  the key's character is looked up at the right shift level; the key is a character or an
  X keysym name (`"Return"`, `"Left"`, `"F5"`).
- **Arbitrary Unicode** via the xdotool technique: temporarily bind the codepoint to a
  spare keycode, send the press/release, then restore the keycode. GNUstep refreshes its
  keymap on the resulting `MappingNotify` (a settle delay covers that); Latin-1 codepoints
  use the bare value as the keysym, U+0100+ the `0x01000000` direct-Unicode form.

## Testing

Built **warning-free on FreeBSD 15 (gnustep-make 2.9.3)**; the tip links **only `libX11`**
(via `pkg-config`, from `/usr/local`) — verified with `ldd`. Each commit builds in
isolation; the series re-applies onto pristine and the result is byte-identical to the
validated build (bisect-clean).

Runtime-validated against a real GNUstep app on a live X11 session, driving `X11Support`
directly: clicks deliver `mouseDown` at the right window-local point; two rapid clicks
register `clickCount` 1 then 2 (server-timestamp path); typing produces `a`, shifted `B`,
digit `7`; chords `shift+a` ⇒ `A`, `control+c` ⇒ Control flag set, named `Return`; Unicode
`x11_type` round-trips `é` (Latin-1), `中` (BMP), `😀` (astral surrogate pair). Also
exercised end-to-end through a consumer UI suite (clicks, text entry, modals, table
selection, menus, `x11_activate_window`): 190 checks green.

**Not** yet build-tested on Linux (no Linux host) — commit 1 uses `pkg-config` specifically
so it should need no change there.

Notes: this input path is **X11-only**; a Wayland session would need a different backend.
Does not touch the theme-side service.
