### PR TITLE
Menu: detect DBUS on OpenBSD

### DIFF
--- a/Menu/configure
+++ b/Menu/configure
@@ -45,7 +45,7 @@ DBUS_LIBS="-ldbus-1"
 
 # Platform-specific library paths
 case "$OS" in
-    FreeBSD|NextBSD)
+    FreeBSD|NextBSD|OpenBSD)
         DBUS_LIBS="-L/usr/local/lib -ldbus-1"
         ;;
     *)
@@ -87,8 +87,8 @@ case "$OS" in
             DBUS_CFLAGS="$DBUS_CFLAGS -I/usr/lib/dbus-1.0/include"
         fi
         ;;
-    FreeBSD|NextBSD)
-        # FreeBSD/NextBSD typically use /usr/local
+    FreeBSD|NextBSD|OpenBSD)
+        # FreeBSD/NextBSD/OpenBSD typically use /usr/local
         if [ -z "$DBUS_CFLAGS" ]; then
             DBUS_CFLAGS="-I/usr/local/include/dbus-1.0 -I/usr/local/include"
             if [ -d "/usr/local/lib/dbus-1.0/include" ]; then
@@ -118,6 +118,10 @@ else
         FreeBSD|NextBSD)
             echo "Please install DBUS:"
             echo "  sudo pkg install dbus"
+            ;;
+        OpenBSD)
+            echo "Please install DBUS:"
+            echo "  doas pkg_add dbus"
             ;;
         *)
             echo "Please install DBUS development headers and libraries"


### PR DESCRIPTION
## Problem

The OpenBSD build of the Menu app fails at configure:

```
Detected OS: OpenBSD
Found dbus/dbus.h in /usr/local/include/dbus-1.0
Found dbus/dbus-arch-deps.h in /usr/local/lib/dbus-1.0/include
DBUS_LIBS: -ldbus-1
Error: DBUS is required but not found or not working
```

The headers are found, but on OpenBSD `libdbus-1` lives in `/usr/local/lib`, which is not on the default linker search path. `DBUS_LIBS` fell through to the default `-ldbus-1` (no `-L/usr/local/lib`), so the test link failed and configure aborted.

## Fix

OpenBSD uses `/usr/local` for DBUS just like FreeBSD, so add `OpenBSD` to the existing `FreeBSD|NextBSD` `/usr/local` branches in `Menu/configure`:
- `DBUS_LIBS` becomes `-L/usr/local/lib -ldbus-1`.
- Same `/usr/local` CFLAGS fallback.
- OpenBSD-specific install hint (`doas pkg_add dbus`).

Mirrors the earlier NextBSD handling. No effect on other platforms.

## Context

Surfaced by the OpenBSD port of gershwin-developer (gershwin-developer#33), whose build now reaches gershwin-components after the gershwin-workspace and gershwin-terminal OpenBSD fixes landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)