### PR TITLE
Menu: enable ARC on OpenBSD

### DIFF
--- a/Menu/GNUmakefile.in
+++ b/Menu/GNUmakefile.in
@@ -116,6 +116,10 @@ ifeq ($(UNAME_S),NextBSD)
 	Menu_GUI_LIBS += -L/usr/lib/system
 	Menu_LDFLAGS += -Wl,-rpath,/usr/lib/system
 endif
+ifeq ($(UNAME_S),OpenBSD)
+	ADDITIONAL_OBJCFLAGS = -Wall -Wextra -O2 -fobjc-runtime=gnustep-2.0 -fobjc-arc -Wno-unused-parameter -D_BSD_SOURCE
+	ADDITIONAL_CPPFLAGS = @DBUS_CFLAGS@
+endif
 
 # Profiling: build with  make PROFILE=1  to enable CPU instrumentation.
 # When enabled, a summary is printed every 10s and on SIGUSR1.


### PR DESCRIPTION
## Problem

After DBUS detection succeeds, the Menu app fails to compile on OpenBSD:

```
MenuApplication.m:388:5: error: cannot create __weak reference in file using manual reference counting
    __weak typeof(self) weakSelf = self;
```

`MenuApplication.m` (and `WindowMonitor.m`, `MenuProtocolManager.m`) use `__weak`, which requires ARC. `GNUmakefile.in` enables `-fobjc-arc` in per-OS `ifeq` blocks for Linux/FreeBSD/NextBSD, but OpenBSD matched none of them and compiled under manual reference counting.

## Fix

Add an `ifeq ($(UNAME_S),OpenBSD)` block mirroring the BSD flags (`-fobjc-arc`, `-D_BSD_SOURCE`), exactly the way NextBSD was handled. No effect on other platforms.

## Context

Part of the OpenBSD port (gershwin-developer#33), continuing after the Menu DBUS detection fix (#72).

**Heads-up:** `CrashHandler.m` uses `<execinfo.h>` / `backtrace()`, which is not in the OpenBSD base system. That's the likely next OpenBSD break (it compiles after `MenuApplication.m`), and will need either the `libexecinfo` package wired in or the backtrace path gated off on OpenBSD — handled separately once CI confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)