### PR TITLE
Menu: link libexecinfo on OpenBSD

### DIFF
--- a/Menu/GNUmakefile.in
+++ b/Menu/GNUmakefile.in
@@ -119,6 +119,9 @@ endif
 ifeq ($(UNAME_S),OpenBSD)
 	ADDITIONAL_OBJCFLAGS = -Wall -Wextra -O2 -fobjc-runtime=gnustep-2.0 -fobjc-arc -Wno-unused-parameter -D_BSD_SOURCE
 	ADDITIONAL_CPPFLAGS = @DBUS_CFLAGS@
+	# backtrace()/backtrace_symbols_fd() (used by CrashHandler.m) come from
+	# libexecinfo under /usr/local on OpenBSD, not from libc.
+	Menu_TOOL_LIBS += -L/usr/local/lib -lexecinfo
 endif
 
 # Profiling: build with  make PROFILE=1  to enable CPU instrumentation.


### PR DESCRIPTION
## Problem

With ARC enabled (#73), Menu now compiles fully on OpenBSD but fails at link:

```
ld: error: undefined symbol: backtrace
ld: error: undefined symbol: backtrace_symbols_fd
  referenced by CrashHandler.m
```

`CrashHandler.m` uses `backtrace()` / `backtrace_symbols_fd()`. The `execinfo.h` header is available on OpenBSD (the file compiles), but the symbols live in **libexecinfo** under `/usr/local`, not in libc, so the app fails to link.

## Fix

Add `-L/usr/local/lib -lexecinfo` to the OpenBSD `ifeq` block, mirroring the `-lexecinfo` already linked for FreeBSD/NextBSD (whose libexecinfo is in base). No effect on other platforms.

## Context

Part of the OpenBSD port (gershwin-developer#33), continuing after the Menu DBUS (#72) and ARC (#73) fixes. To guarantee the library is present, `libexecinfo` is also being added to gershwin-developer's `openbsd.txt` package list on the #33 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)