### PR TITLE
DirectoryServices: don't link -lcrypt on OpenBSD

### DIFF
--- a/DirectoryServices/dscli/GNUmakefile
+++ b/DirectoryServices/dscli/GNUmakefile
@@ -9,7 +9,12 @@ dscli_OBJC_FILES = \
 	DSPlatformLinux.m
 
 dscli_OBJCFLAGS = -fobjc-arc
-dscli_LDFLAGS = -lcrypt -Wl,-rpath,$(GNUSTEP_SYSTEM_LIBRARIES)
+dscli_LDFLAGS = -Wl,-rpath,$(GNUSTEP_SYSTEM_LIBRARIES)
+# crypt(3) is in a separate libcrypt on Linux and FreeBSD, but is part of libc
+# on OpenBSD (there is no libcrypt to link against).
+ifneq ($(findstring openbsd,$(GNUSTEP_HOST_OS)),openbsd)
+dscli_LDFLAGS += -lcrypt
+endif
 
 # Install to /System/Library/Tools
 GNUSTEP_INSTALLATION_DOMAIN = SYSTEM

--- a/DirectoryServices/dshelper/GNUmakefile
+++ b/DirectoryServices/dshelper/GNUmakefile
@@ -10,7 +10,12 @@ dshelper_HEADER_FILES = \
 	dshelper.h
 
 dshelper_OBJCFLAGS = -fobjc-arc
-dshelper_LDFLAGS = -lcrypt -ldispatch -lBlocksRuntime
+dshelper_LDFLAGS = -ldispatch -lBlocksRuntime
+# crypt(3) is in a separate libcrypt on Linux and FreeBSD, but is part of libc
+# on OpenBSD (there is no libcrypt to link against).
+ifneq ($(findstring openbsd,$(GNUSTEP_HOST_OS)),openbsd)
+dshelper_LDFLAGS += -lcrypt
+endif
 
 # Install to /System/Library/Tools
 GNUSTEP_INSTALLATION_DOMAIN = SYSTEM


### PR DESCRIPTION
## Problem

DirectoryServices' `dshelper` tool fails to link on OpenBSD:

```
ld: error: unable to find library -lcrypt
```

`dshelper` (and `dscli`) link `-lcrypt`. On OpenBSD, `crypt(3)` is part of **libc** — there is no separate `libcrypt` to link against (unlike Linux and FreeBSD, which both ship one).

## Fix

Gate `-lcrypt` off for OpenBSD in both `dshelper` and `dscli` GNUmakefiles, using the same `GNUSTEP_HOST_OS` mechanism the files already use for platform-specific install steps. It remains linked on Linux/FreeBSD. (`dscli` is fixed too since the build is serial and would hit the same error immediately after.)

## Context

Part of the OpenBSD port (gershwin-developer#33), continuing after the Menu fixes. Menu now builds and installs; DirectoryServices is the next component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)