### PR TITLE
nss_gershwin: include <stdint.h> for uintptr_t

### DIFF
--- a/DirectoryServices/nss_gershwin/nss_gershwin.c
+++ b/DirectoryServices/nss_gershwin/nss_gershwin.c
@@ -16,6 +16,7 @@
 #endif
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <unistd.h>
 


### PR DESCRIPTION
## Problem

`nss_gershwin` fails to compile on OpenBSD:

```
nss_gershwin.c:294:5: error: unknown type name 'uintptr_t'; did you mean 'intptr_t'?
    uintptr_t align = (uintptr_t)buf % sizeof(char *);
```

The file uses `uintptr_t` but never includes `<stdint.h>` — it relied on the type being pulled in transitively by another header (true on glibc, not on OpenBSD).

## Fix

Add `#include <stdint.h>`, the standard home of `uintptr_t`. Harmless on platforms where it was already available.

## Context

Part of the OpenBSD port (gershwin-developer#33). The Linux-NSS headers (`shadow.h`, `nss.h`, `nsswitch.h`) are already `#ifdef __linux__`-guarded with non-Linux fallbacks, so this `uintptr_t` include was the only OpenBSD compile gap in this module. Continues after the DirectoryServices `-lcrypt` fix (#75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)