### PR TITLE
LoginWindow: port process/sysctl code to OpenBSD

### DIFF
--- a/LoginWindow/LoginWindow.m
+++ b/LoginWindow/LoginWindow.m
@@ -13,7 +13,23 @@
 #import <login_cap.h>
 #import <sys/sysctl.h>
 #import <sys/user.h>
+#if defined(__OpenBSD__)
+#import <util.h>
+// OpenBSD's struct kinfo_proc uses p_* field names (and p__pgid, since
+// <sys/proc.h> hijacks p_pgid); FreeBSD uses ki_*.
+#define GW_KP_PID   p_pid
+#define GW_KP_PPID  p_ppid
+#define GW_KP_SID   p_sid
+#define GW_KP_PGID  p__pgid
+#define GW_KP_COMM  p_comm
+#else
 #import <libutil.h>
+#define GW_KP_PID   ki_pid
+#define GW_KP_PPID  ki_ppid
+#define GW_KP_SID   ki_sid
+#define GW_KP_PGID  ki_pgid
+#define GW_KP_COMM  ki_comm
+#endif
 #endif
 #import <string.h>
 #import <grp.h>
@@ -2099,11 +2115,19 @@ static bool isDetachedDaemon(const char *comm)
     closedir(proc_dir);
 
 #else
-    // BSD implementation using sysctl
+    // BSD implementation using sysctl. OpenBSD's KERN_PROC needs a 6-element
+    // mib carrying the struct size and element count; FreeBSD uses 4.
+#if defined(__OpenBSD__)
+    int mib[6] = {CTL_KERN, KERN_PROC, KERN_PROC_UID, (int)uid,
+                  sizeof(struct kinfo_proc), 0};
+    int miblen = 6;
+#else
     int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_UID, uid};
+    int miblen = 4;
+#endif
     size_t size = 0;
 
-    if (sysctl(mib, 4, NULL, &size, NULL, 0) != 0) {
+    if (sysctl(mib, miblen, NULL, &size, NULL, 0) != 0) {
         NSDebugLog(@"Failed to get process list size: %s", strerror(errno));
         return;
     }
@@ -2114,7 +2138,10 @@ static bool isDetachedDaemon(const char *comm)
         return;
     }
 
-    if (sysctl(mib, 4, procs, &size, NULL, 0) != 0) {
+#if defined(__OpenBSD__)
+    mib[5] = (int)(size / sizeof(struct kinfo_proc));
+#endif
+    if (sysctl(mib, miblen, procs, &size, NULL, 0) != 0) {
         NSDebugLog(@"Failed to get process list: %s", strerror(errno));
         free(procs);
         return;
@@ -2122,22 +2149,22 @@ static bool isDetachedDaemon(const char *comm)
 
     int numProcs = size / sizeof(struct kinfo_proc);
     for (int i = 0; i < numProcs; i++) {
-        pid_t pid = procs[i].ki_pid;
+        pid_t pid = procs[i].GW_KP_PID;
         if (pid <= 1 || pid == getpid())
             continue;
 
         bool shouldKill = false;
 
         // Session-related checks
-        if (procs[i].ki_ppid == sessionPid || procs[i].ki_sid == sessionPid ||
-            procs[i].ki_pgid == sessionPid) {
-            NSDebugLog(@"Found session-related process: PID=%d, Command=%s", pid, procs[i].ki_comm);
+        if (procs[i].GW_KP_PPID == sessionPid || procs[i].GW_KP_SID == sessionPid ||
+            procs[i].GW_KP_PGID == sessionPid) {
+            NSDebugLog(@"Found session-related process: PID=%d, Command=%s", pid, procs[i].GW_KP_COMM);
             shouldKill = true;
         }
 
         // Detached daemon check
-        if (!shouldKill && isDetachedDaemon(procs[i].ki_comm)) {
-            NSDebugLog(@"Found detached daemon: PID=%d, Command=%s", pid, procs[i].ki_comm);
+        if (!shouldKill && isDetachedDaemon(procs[i].GW_KP_COMM)) {
+            NSDebugLog(@"Found detached daemon: PID=%d, Command=%s", pid, procs[i].GW_KP_COMM);
             shouldKill = true;
         }
 
@@ -2736,74 +2763,115 @@ static bool isDetachedDaemon(const char *comm)
     closedir(proc_dir);
     
 #else
-    // BSD implementation using sysctl
+    // BSD implementation using sysctl. OpenBSD's KERN_PROC needs a 6-element
+    // mib carrying the struct size and element count; FreeBSD uses 3.
+#if defined(__OpenBSD__)
+    int mib[6] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0,
+                  sizeof(struct kinfo_proc), 0};
+    int miblen = 6;
+#else
     int mib[3] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL};
+    int miblen = 3;
+#endif
     size_t size = 0;
-    
-    if (sysctl(mib, 3, NULL, &size, NULL, 0) != 0) {
+
+    if (sysctl(mib, miblen, NULL, &size, NULL, 0) != 0) {
         NSDebugLLog(@"gwcomp", @"[DEBUG] Failed to get process list size: %s", strerror(errno));
         return;
     }
-    
+
     struct kinfo_proc *procs = malloc(size);
     if (!procs) {
         NSDebugLLog(@"gwcomp", @"[DEBUG] Failed to allocate memory for process list");
         return;
     }
-    
-    if (sysctl(mib, 3, procs, &size, NULL, 0) != 0) {
+
+#if defined(__OpenBSD__)
+    mib[5] = (int)(size / sizeof(struct kinfo_proc));
+#endif
+    if (sysctl(mib, miblen, procs, &size, NULL, 0) != 0) {
         NSDebugLLog(@"gwcomp", @"[DEBUG] Failed to get process list: %s", strerror(errno));
         free(procs);
         return;
     }
-    
+
     int numProcs = size / sizeof(struct kinfo_proc);
     NSDebugLLog(@"gwcomp", @"[DEBUG] Checking %d processes for X server cleanup", numProcs);
-    
+
     for (int i = 0; i < numProcs; i++) {
-        pid_t pid = procs[i].ki_pid;
-        
+        pid_t pid = procs[i].GW_KP_PID;
+
         // Skip kernel processes, init, and our own process
         if (pid <= 1 || pid == getpid()) {
             continue;
         }
-        
-        // Get command arguments for this process
-        int mib_args[4] = {CTL_KERN, KERN_PROC, KERN_PROC_ARGS, pid};
+
+        // Build a searchable command-line string for this process.
+        NSMutableString *cmdlineStr = [NSMutableString string];
+#if defined(__OpenBSD__)
+        // OpenBSD: KERN_PROC_ARGS sits directly under CTL_KERN and, with
+        // KERN_PROC_ARGV, returns an argv pointer array into the buffer.
+        int mib_args[4] = {CTL_KERN, KERN_PROC_ARGS, pid, KERN_PROC_ARGV};
         size_t args_size = 0;
-        
+
         if (sysctl(mib_args, 4, NULL, &args_size, NULL, 0) != 0) {
             continue; // Process might have disappeared
         }
-        
+
+        char **argv = malloc(args_size);
+        if (!argv) {
+            continue;
+        }
+
+        if (sysctl(mib_args, 4, argv, &args_size, NULL, 0) != 0) {
+            free(argv);
+            continue;
+        }
+
+        for (char **ap = argv; *ap != NULL; ap++) {
+            if ([cmdlineStr length] > 0) {
+                [cmdlineStr appendString:@" "];
+            }
+            [cmdlineStr appendString:[NSString stringWithUTF8String:*ap]];
+        }
+
+        free(argv);
+#else
+        // FreeBSD: KERN_PROC_ARGS returns a flat NUL-separated argument buffer.
+        int mib_args[4] = {CTL_KERN, KERN_PROC, KERN_PROC_ARGS, pid};
+        size_t args_size = 0;
+
+        if (sysctl(mib_args, 4, NULL, &args_size, NULL, 0) != 0) {
+            continue; // Process might have disappeared
+        }
+
         char *args = malloc(args_size);
         if (!args) {
             continue;
         }
-        
+
         if (sysctl(mib_args, 4, args, &args_size, NULL, 0) != 0) {
             free(args);
             continue;
         }
-        
-        // Build a searchable string from arguments
-        NSMutableString *cmdlineStr = [NSMutableString string];
+
         char *p = args;
         char *end = args + args_size;
-        
+
         while (p < end) {
             size_t len = strlen(p);
             if (len == 0) break;
-            
+
             if ([cmdlineStr length] > 0) {
                 [cmdlineStr appendString:@" "];
             }
             [cmdlineStr appendString:[NSString stringWithUTF8String:p]];
             p += len + 1;
         }
-        
+
         free(args);
-        
+#endif
+
         // Check if command line matches pattern and display number
         if ([cmdlineStr rangeOfString:pattern].location != NSNotFound &&
             [cmdlineStr rangeOfString:displayNum].location != NSNotFound) {

--- a/LoginWindow/LoginWindow_main.m
+++ b/LoginWindow/LoginWindow_main.m
@@ -230,34 +230,51 @@ static BOOL isProcessRunningByName(const char *processName)
     return found;
     
 #else
-    // BSD implementation using sysctl
+    // BSD implementation using sysctl. OpenBSD's KERN_PROC needs a 6-element
+    // mib carrying the struct size and element count; FreeBSD uses 3. The
+    // command field is p_comm on OpenBSD, ki_comm on FreeBSD.
+#if defined(__OpenBSD__)
+    int mib[6] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0,
+                  sizeof(struct kinfo_proc), 0};
+    int miblen = 6;
+#else
     int mib[3] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL};
+    int miblen = 3;
+#endif
     size_t size = 0;
-    
-    if (sysctl(mib, 3, NULL, &size, NULL, 0) != 0) {
+
+    if (sysctl(mib, miblen, NULL, &size, NULL, 0) != 0) {
         return NO;
     }
-    
+
     struct kinfo_proc *procs = malloc(size);
     if (!procs) {
         return NO;
     }
-    
-    if (sysctl(mib, 3, procs, &size, NULL, 0) != 0) {
+
+#if defined(__OpenBSD__)
+    mib[5] = (int)(size / sizeof(struct kinfo_proc));
+#endif
+    if (sysctl(mib, miblen, procs, &size, NULL, 0) != 0) {
         free(procs);
         return NO;
     }
-    
+
     int numProcs = size / sizeof(struct kinfo_proc);
     BOOL found = NO;
-    
+
     for (int i = 0; i < numProcs; i++) {
-        if (strcmp(procs[i].ki_comm, processName) == 0) {
+#if defined(__OpenBSD__)
+        const char *pcomm = procs[i].p_comm;
+#else
+        const char *pcomm = procs[i].ki_comm;
+#endif
+        if (strcmp(pcomm, processName) == 0) {
             found = YES;
             break;
         }
     }
-    
+
     free(procs);
     return found;
 #endif


### PR DESCRIPTION
## Problem

With PAM resolved (via openpam), LoginWindow now compiles further but hits FreeBSD-vs-OpenBSD kernel-API differences in its non-Linux (`#else`/"BSD") code paths:

```
LoginWindow.m:16: fatal error: 'libutil.h' file not found
LoginWindow_main.m:255: no member named 'ki_comm' in 'struct kinfo_proc'; did you mean 'p_comm'?
```

The "BSD" branches were written for **FreeBSD** specifically. OpenBSD differs in three places (across `LoginWindow_main.m` and `LoginWindow.m`).

## Changes (OpenBSD branches; FreeBSD/Linux unchanged)

1. **Header** — `<util.h>` on OpenBSD instead of `<libutil.h>`.
2. **`struct kinfo_proc` fields** — FreeBSD `ki_*` vs OpenBSD `p_*`, including `p__pgid` (OpenBSD spells pgid with a double underscore because `<sys/proc.h>` hijacks `p_pgid`). Done via `GW_KP_*` aliases in `LoginWindow.m` and an inline guard in `LoginWindow_main.m`.
3. **`KERN_PROC` sysctl** — OpenBSD requires a **6-element mib** carrying `sizeof(struct kinfo_proc)` and the element count; FreeBSD uses 3 (`KERN_PROC_ALL`) or 4 (`KERN_PROC_UID`).
4. **`KERN_PROC_ARGS`** — FreeBSD returns a flat NUL-separated buffer under `{CTL_KERN, KERN_PROC, KERN_PROC_ARGS, pid}`; OpenBSD uses `{CTL_KERN, KERN_PROC_ARGS, pid, KERN_PROC_ARGV}` and returns an **argv pointer array**, parsed accordingly.

Field names / mib layout verified against OpenBSD `sys/sys/sysctl.h`.

## Scope note

This turned out larger than a header/field fix — three sysctl sites including the structurally-different `KERN_PROC_ARGS`. It's written against OpenBSD's documented APIs but **could not be compiled locally** (no OpenBSD/GNUstep here), so the OpenBSD CI in gershwin-developer#33 is the validator; it may need a follow-up iteration if a detail is off.

## Context

Part of the OpenBSD port (gershwin-developer#33), after the Menu and DirectoryServices fixes and the `openpam` package. Separately, whether LoginWindow actually **authenticates** on OpenBSD is tracked in #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)