### PR TITLE
Menu: drop stale pkgwrap references from comments

### DIFF
--- a/Menu/DBusMenuActionHandler.m
+++ b/Menu/DBusMenuActionHandler.m
@@ -14,7 +14,7 @@
 // dictionary under the key "dbusInfo".  NSMenuItem copies retain the
 // representedObject, so the info survives the deep copy performed by
 // MenuProtocolManager.prependGNUstepStubIfNeeded (which merges a GNUstep stub
-// menu with a DBus menu for pkgwrap-bundled apps).  The previous scheme
+// menu with a DBus menu for bundled apps).  The previous scheme
 // keyed a static dict by the item's pointer, which broke as soon as the
 // menu was copied.
 static NSString *const kDBusInfoKey = @"dbusInfo";

--- a/Menu/MenuProtocolManager.m
+++ b/Menu/MenuProtocolManager.m
@@ -154,11 +154,7 @@
 }
 
 /* If a non-GNUstep menu was found, check whether the GNUstep handler also
- * has a stub menu for this window (registered by pkgwrap-menu-stub).  If so,
- * prepend the stub items to give bundled apps a standard app-name menu
- * alongside their native DBus menus. */
-/* If a non-GNUstep menu was found, check whether the GNUstep handler also
- * has a stub menu for this window (registered by pkgwrap-menu-stub).  If so,
+ * has a stub menu for this window (registered by a stub-menu helper).  If so,
  * prepend the stub items to give bundled apps a standard app-name menu
  * alongside their native DBus menus.
  *


### PR DESCRIPTION
## What

Follow-up to #80 (which removed the `pkgwrap/` directory). Cleans up the only remaining `pkgwrap` mentions in the repo — descriptive comments in `Menu/`:

- `DBusMenuActionHandler.m`: "…for **pkgwrap-bundled** apps" → "…for bundled apps".
- `MenuProtocolManager.m`: two comment blocks said the stub menu is "registered by **pkgwrap-menu-stub**" → reworded to "registered by a stub-menu helper". Also collapses an accidental duplicate of that comment block.

Comments only — no code changes. After this, `grep -r pkgwrap` over the repo is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)