### PR TITLE
OpenBSD: fix GlobalShortcuts sysctl + Network/Sharing -ldl (proactive sweep)

### DIFF
--- a/GlobalShortcuts/GlobalShortcutsController.m
+++ b/GlobalShortcuts/GlobalShortcutsController.m
@@ -395,34 +395,53 @@ NSArray *parseKeyComboInPrefPane(NSString *keyCombo) {
     return result;
     
 #else
-    // BSD implementation using sysctl
+    // BSD implementation using sysctl. OpenBSD's KERN_PROC needs a 6-element
+    // mib carrying the struct size and element count; FreeBSD uses 3. The
+    // command/pid fields are p_* on OpenBSD, ki_* on FreeBSD.
+#if defined(__OpenBSD__)
+    int mib[6] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0,
+                  sizeof(struct kinfo_proc), 0};
+    int miblen = 6;
+#else
     int mib[3] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL};
+    int miblen = 3;
+#endif
     size_t size = 0;
-    
-    if (sysctl(mib, 3, NULL, &size, NULL, 0) != 0) {
+
+    if (sysctl(mib, miblen, NULL, &size, NULL, 0) != 0) {
         return -1;
     }
-    
+
     struct kinfo_proc *procs = malloc(size);
     if (!procs) {
         return -1;
     }
-    
-    if (sysctl(mib, 3, procs, &size, NULL, 0) != 0) {
+
+#if defined(__OpenBSD__)
+    mib[5] = (int)(size / sizeof(struct kinfo_proc));
+#endif
+    if (sysctl(mib, miblen, procs, &size, NULL, 0) != 0) {
         free(procs);
         return -1;
     }
-    
+
     int numProcs = size / sizeof(struct kinfo_proc);
     pid_t result = -1;
-    
+
     for (int i = 0; i < numProcs; i++) {
-        if (strcmp(procs[i].ki_comm, [processName UTF8String]) == 0) {
-            result = procs[i].ki_pid;
+#if defined(__OpenBSD__)
+        const char *pcomm = procs[i].p_comm;
+        pid_t ppid = procs[i].p_pid;
+#else
+        const char *pcomm = procs[i].ki_comm;
+        pid_t ppid = procs[i].ki_pid;
+#endif
+        if (strcmp(pcomm, [processName UTF8String]) == 0) {
+            result = ppid;
             break;
         }
     }
-    
+
     free(procs);
     return result;
 #endif

--- a/Network/GNUmakefile
+++ b/Network/GNUmakefile
@@ -13,8 +13,14 @@ Network_RESOURCE_FILES = Network.png NetworkInfo.plist
 Network_BUNDLE_LIBS = -lPreferencePanes
 Network_PRINCIPAL_CLASS = NetworkPane
 
-# For dlopen() used to load NetworkManager library
+# For dlopen() used to load NetworkManager library. dlopen/dlsym are in libc on
+# OpenBSD (no libdl to link against), so only add -ldl on other platforms.
+NETWORK_UNAME_S := $(shell uname -s)
+ifeq ($(NETWORK_UNAME_S),OpenBSD)
+Network_LDFLAGS =
+else
 Network_LDFLAGS = -ldl
+endif
 
 PREF_INSTALL_DIR = $(GNUSTEP_SYSTEM_LIBRARY)/Bundles
 HELPER_INSTALL_DIR = $(GNUSTEP_SYSTEM_LIBRARY)/Tools

--- a/Sharing/GNUmakefile
+++ b/Sharing/GNUmakefile
@@ -11,8 +11,14 @@ Sharing_RESOURCE_FILES = Sharing.png SharingInfo.plist
 Sharing_BUNDLE_LIBS = -lPreferencePanes
 Sharing_PRINCIPAL_CLASS = SharingPane
 
-# For network operations
+# For network operations. dlopen/dlsym are in libc on OpenBSD (no libdl to
+# link against), so only add -ldl on other platforms.
+SHARING_UNAME_S := $(shell uname -s)
+ifeq ($(SHARING_UNAME_S),OpenBSD)
+Sharing_LDFLAGS =
+else
 Sharing_LDFLAGS = -ldl
+endif
 
 PREF_INSTALL_DIR = $(GNUSTEP_SYSTEM_LIBRARY)/Bundles
 HELPER_INSTALL_DIR = $(GNUSTEP_SYSTEM_LIBRARY)/Tools


### PR DESCRIPTION
## What

The OpenBSD build hit the same `kinfo_proc` field error in `GlobalShortcuts` that LoginWindow had. Rather than fix it alone and discover the rest one slow CI round at a time, this sweeps **all built components** for the recurring FreeBSD-isms (`kinfo_proc` `ki_*` fields, `KERN_PROC` mib shape, `-ldl`, `libutil.h`, `clearenv`, `syscall()`) and checks whether each is actually reachable on OpenBSD.

## Fixed

- **`GlobalShortcuts/GlobalShortcutsController.m`** — the non-Linux (`#else`) process lookup used FreeBSD's 3-element `KERN_PROC` mib and `ki_comm`/`ki_pid`. Added the OpenBSD path: 6-element mib carrying `sizeof(struct kinfo_proc)` + element count, and `p_comm`/`p_pid`.
- **`Network/GNUmakefile`, `Sharing/GNUmakefile`** — dropped `-ldl` on OpenBSD (dlopen/dlsym are in libc there; no `libdl` to link), same as the earlier pkgwrap issue.

## Checked and left alone (already OpenBSD-safe)

- **`Processes/ProcessesController.m`** — its `kinfo_proc`/sysctl code is entirely under `#if defined(__FreeBSD__)`, so OpenBSD never compiles it. (Its grep hits are FreeBSD-guarded.)
- **`Console`** — no FreeBSD-specific kernel APIs.
- **`Phone`** — not part of the system build (`build_components`); has `libutil.h` + `-ldl` of its own, left for whenever it's wired in.

FreeBSD/Linux paths unchanged.

## Context

Part of the OpenBSD port (gershwin-developer#33), continuing after LoginWindow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)