### PR TITLE
Sound: don't build OSSBackend on OpenBSD

### DIFF
--- a/Sound/GNUmakefile
+++ b/Sound/GNUmakefile
@@ -6,8 +6,14 @@ Sound_OBJC_FILES = \
 	SoundPane.m \
 	SoundController.m \
 	SoundModels.m \
-	ALSABackend.m \
-	OSSBackend.m
+	ALSABackend.m
+
+# OSSBackend uses <sys/soundcard.h> (OSS), which OpenBSD does not provide
+# (OpenBSD uses sndio). Build it everywhere except OpenBSD.
+SOUND_UNAME_S := $(shell uname -s)
+ifneq ($(SOUND_UNAME_S),OpenBSD)
+Sound_OBJC_FILES += OSSBackend.m
+endif
 
 Sound_RESOURCE_FILES = Sound.png SoundInfo.plist
 Sound_BUNDLE_LIBS = -lPreferencePanes

--- a/Sound/SoundController.m
+++ b/Sound/SoundController.m
@@ -72,8 +72,9 @@ static const CGFloat kTableRowHeight = 18.0;
             }
         }
 
-#if !defined(__FreeBSD__) && !defined(__DragonFly__)
+#if !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__OpenBSD__)
         // On non-BSD systems, also try OSS as fallback (e.g., OSS4 on Linux)
+        // (OpenBSD excluded: no OSS there; sndio backend is a future addition.)
         if (backend == nil) {
             OSSBackend *ossBackend = [[OSSBackend alloc] init];
             if ([ossBackend isAvailable]) {


### PR DESCRIPTION
## Problem

Sound fails to compile on OpenBSD:

```
OSSBackend.m:20:9: fatal error: 'sys/soundcard.h' file not found
```

`OSSBackend.m` uses the **OSS** API (`<sys/soundcard.h>`, `/dev/mixer`, `SNDCTL_*` ioctls). OpenBSD doesn't ship OSS — it uses **sndio**. (FreeBSD has OSS, Linux has ALSA.)

## Fix

- **GNUmakefile**: exclude `OSSBackend.m` from `Sound_OBJC_FILES` on OpenBSD only.
- **SoundController.m**: also exclude OpenBSD from the non-BSD "try OSS as fallback" path.

`ALSABackend` already compiles on every platform (it shells out to tools and gates on `isAvailable`), and `SoundController` degrades gracefully to "no audio backend available." So the Sound prefPane **builds and runs on OpenBSD with no audio backend** for now.

## Follow-up

A native **sndio** backend is the proper way to give OpenBSD working audio control — out of scope here, noted in the code.

## Context

Part of the OpenBSD port (gershwin-developer#33), after the GlobalShortcuts/Network/Sharing sweep (#82).

🤖 Generated with [Claude Code](https://claude.com/claude-code)