### PR TITLE
Processes: read total memory without sysctlbyname on OpenBSD

### DIFF
--- a/Processes/ProcessesController.m
+++ b/Processes/ProcessesController.m
@@ -83,7 +83,16 @@ static long getTotalSystemMemoryKB(void) {
     // BSD and other Unix-like systems: prefer sysctlbyname for portability
     uint64_t memsize = 0;
     size_t len = sizeof(memsize);
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#if defined(__OpenBSD__)
+    // OpenBSD has no sysctlbyname(); read physical memory via the numeric mib.
+#ifdef HW_PHYSMEM64
+    int mib[2] = {CTL_HW, HW_PHYSMEM64};
+    len = sizeof(memsize);
+    if (sysctl(mib, 2, &memsize, &len, NULL, 0) == 0) {
+        totalMemory = (long)(memsize / 1024);
+    }
+#endif
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
     // Try several common sysctl names across BSDs/macOS
     const char *names[] = { "hw.memsize", "hw.physmem", "hw.realmem", "hw.physmem64", NULL };
     const char **n;


### PR DESCRIPTION
## Problem

Processes fails to link on OpenBSD:

```
ld: error: undefined symbol: sysctlbyname
  referenced by ProcessesController.m
```

The total-memory probe calls `sysctlbyname()` and its guard included `__OpenBSD__`. OpenBSD has **no `sysctlbyname()`** (you use numeric mibs), and the numeric fallback in that branch used `HW_MEMSIZE` (macOS-only), so OpenBSD had no working path at all.

## Fix

- Add an OpenBSD branch that reads physical memory via the numeric `{CTL_HW, HW_PHYSMEM64}` mib.
- Drop `__OpenBSD__` from the `sysctlbyname` branch (now `#elif … __APPLE__ || __FreeBSD__ || __NetBSD__ || __DragonFly__`).

Other platforms unchanged.

## Proactive check

The other `sysctlbyname` uses in the repo are already guarded so they don't reach OpenBSD:
- `Network/network-helper.c`, `Network/NetworkController.m` — under `#if defined(__FreeBSD__) || defined(__DragonFly__)`.
- `Menu/StatusItems/SystemMonitor/SystemMonitorProvider.m` — under `#ifdef __FreeBSD__`.

(Confirmed by the fact that Network and Menu already build on OpenBSD.)

## Context

Part of the OpenBSD port (gershwin-developer#33). Note: the per-process `kinfo_proc` code in this same file is separately `#if defined(__FreeBSD__)`-guarded, so OpenBSD currently shows total memory but falls back to `ps`/`/proc`-style enumeration paths — fine for building; a fuller OpenBSD process-listing backend could come later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)