### PR TITLE
Assistants: embed framework safely on OpenBSD (conditional)

### DIFF
--- a/Assistants/CreateLiveMediaAssistant/GNUmakefile
+++ b/Assistants/CreateLiveMediaAssistant/GNUmakefile
@@ -48,6 +48,11 @@ include $(GNUSTEP_MAKEFILES)/application.make
 after-all::
 	@echo "Copying GSAssistantFramework into app bundle..."
 	@mkdir -p $(APP_NAME).app/Frameworks
+	@# after-all runs more than once. On OpenBSD, cp cannot overwrite the
+	@# already-embedded framework's symlinked Versions/Current on the second
+	@# pass, so remove the prior copy first there only. Linux/FreeBSD cp handle
+	@# the re-copy fine, so their behaviour is unchanged.
+	@if [ "$$(uname -s)" = "OpenBSD" ]; then rm -rf $(APP_NAME).app/Frameworks/GSAssistantFramework.framework; fi
 	@cp -R ../AssistantFramework/GSAssistantFramework.framework $(APP_NAME).app/Frameworks/
 	@echo "Framework embedded in $(APP_NAME).app/Frameworks/"
 	@echo "Fixing localized resource structure..."

--- a/Assistants/InstallationAssistant/GNUmakefile
+++ b/Assistants/InstallationAssistant/GNUmakefile
@@ -28,6 +28,11 @@ include $(GNUSTEP_MAKEFILES)/application.make
 after-all::
 	@echo "Copying GSAssistantFramework into app bundle..."
 	@mkdir -p $(APP_NAME).app/Frameworks
+	@# after-all runs more than once. On OpenBSD, cp cannot overwrite the
+	@# already-embedded framework's symlinked Versions/Current on the second
+	@# pass, so remove the prior copy first there only. Linux/FreeBSD cp handle
+	@# the re-copy fine, so their behaviour is unchanged.
+	@if [ "$$(uname -s)" = "OpenBSD" ]; then rm -rf $(APP_NAME).app/Frameworks/GSAssistantFramework.framework; fi
 	@cp -R ../AssistantFramework/GSAssistantFramework.framework $(APP_NAME).app/Frameworks/
 	@echo "Framework embedded in $(APP_NAME).app/Frameworks/"
 	@echo "Fixing localized resource structure..."


### PR DESCRIPTION
## Problem

The last component, `CreateLiveMediaAssistant`, fails on OpenBSD while embedding the framework:

```
cp: cannot overwrite directory CreateLiveMediaAssistant.app/Frameworks/GSAssistantFramework.framework/Versions/Current
    with non-directory ../AssistantFramework/GSAssistantFramework.framework/Versions/Current
```

`gnustep-make` invokes `after-all` more than once. The first pass copies `GSAssistantFramework.framework` into the app bundle; on the second pass OpenBSD's `cp` won't overwrite the already-embedded framework, because its `Versions/Current` is a directory at the destination but a symlink in the source. Linux/FreeBSD `cp` overwrite this fine (which is why they're green).

## Fix (OpenBSD-only, conditional)

Guard a pre-copy cleanup behind `uname -s = OpenBSD`:

```make
@if [ "$$(uname -s)" = "OpenBSD" ]; then rm -rf $(APP_NAME).app/Frameworks/GSAssistantFramework.framework; fi
@cp -R ../AssistantFramework/GSAssistantFramework.framework $(APP_NAME).app/Frameworks/
```

- **Linux/FreeBSD: completely unchanged** — they still run the same `cp -R` with no removal.
- **OpenBSD**: removes its prior embedded copy first so the re-copy starts clean. The removed path is only this app's copy of the framework (regenerated by the very next `cp`); the source framework and everything else are untouched.

Applied to the two assistants that the system build actually builds: `CreateLiveMediaAssistant` and `InstallationAssistant`.

## Note

Five other assistants (`DebianRuntimeInstaller`, `SystemSetupAssistant`, `BackupAssistant`, `NetworkSetupAssistant`, `BhyveAssistant`) have the identical `cp -R` embed but are **not** part of the system build, so they're left out of this PR. Easy to apply the same conditional later if/when they're built.

## Context

Part of the OpenBSD port (gershwin-developer#33) — the final component in the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)