### PR TITLE
CI: fix FreeBSD build (pkg OS-version drift + curl/libarchive linkage)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build components inside FreeBSD VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: "14.3"
+          release: "14.4"
           usesh: true
           sync: rsync
           copyback: false
@@ -45,7 +45,7 @@ jobs:
           mem: 4096
           prepare: |
             pkg update
-            pkg install -y git
+            pkg install -y git curl
           run: |
             set -e
             BASE="$(pwd)"

--- a/Assistants/CreateLiveMediaAssistant/GNUmakefile
+++ b/Assistants/CreateLiveMediaAssistant/GNUmakefile
@@ -36,9 +36,20 @@ CreateLiveMediaAssistant_RESOURCE_FILES = \
 # Required frameworks and libraries - use GNUstep naming (copy from working assistant)
 CreateLiveMediaAssistant_GUI_LIBS += -lgnustep-gui -lgnustep-base
 
+# libcurl + libarchive: prefer pkg-config, but fall back to explicit linkage.
+# On FreeBSD, base libarchive ships no .pc file and curl lives under /usr/local,
+# so `pkg-config --libs` silently expands to nothing (the 2>/dev/null hides the
+# failure) and the curl_*/archive_* symbols end up undefined at link time.
+CLM_DEP_CFLAGS := $(shell pkg-config --cflags libcurl libarchive 2>/dev/null)
+CLM_DEP_LIBS   := $(shell pkg-config --libs libcurl libarchive 2>/dev/null)
+ifeq ($(strip $(CLM_DEP_LIBS)),)
+CLM_DEP_CFLAGS := -I/usr/local/include
+CLM_DEP_LIBS   := -L/usr/local/lib -lcurl -larchive
+endif
+
 # Compiler and linker flags - embed framework in bundle with proper rpath
-CreateLiveMediaAssistant_CPPFLAGS += -Wall -Wextra -fobjc-arc -Werror -Wno-unused-parameter -O2 -I$(shell pwd)/../AssistantFramework/GSAssistantFramework.framework/Versions/1/Headers $(shell pkg-config --cflags libcurl libarchive 2>/dev/null)
-CreateLiveMediaAssistant_LDFLAGS += -L$(shell pwd)/../AssistantFramework/GSAssistantFramework.framework/Versions/1 -lGSAssistantFramework $(shell pkg-config --libs libcurl libarchive 2>/dev/null) -Wl,-rpath,'$$ORIGIN/Frameworks/GSAssistantFramework.framework/Versions/1' -Wl,-rpath,/System/Library/Libraries
+CreateLiveMediaAssistant_CPPFLAGS += -Wall -Wextra -fobjc-arc -Werror -Wno-unused-parameter -O2 -I$(shell pwd)/../AssistantFramework/GSAssistantFramework.framework/Versions/1/Headers $(CLM_DEP_CFLAGS)
+CreateLiveMediaAssistant_LDFLAGS += -L$(shell pwd)/../AssistantFramework/GSAssistantFramework.framework/Versions/1 -lGSAssistantFramework $(CLM_DEP_LIBS) -Wl,-rpath,'$$ORIGIN/Frameworks/GSAssistantFramework.framework/Versions/1' -Wl,-rpath,/System/Library/Libraries
 CreateLiveMediaAssistant_LDFLAGS += -ldispatch
 
 include $(GNUSTEP_MAKEFILES)/application.make


### PR DESCRIPTION
## Problem

The **FreeBSD** CI job has been failing since 1750e45 (*"CreateLiveMediaAssistant: streaming curl+libarchive backend"*). Two independent regressions stack up:

### 1. pkg OS-version drift (fails first, in `prepare`)
The `vmactions/freebsd-vm` image was pinned to **14.3** while the FreeBSD package repo advanced to **14.4**, so `pkg install` aborts before any build:
```
wrong version ... To ignore this error set IGNORE_OSVERSION=yes
```
→ Bump the VM to **14.4** to match the repo (same fix already landed in `gershwin-developer`).

### 2. `curl_*` / `archive_*` undefined symbols (fails next, at link)
1750e45 linked the new streaming backend via:
```make
$(shell pkg-config --libs libcurl libarchive 2>/dev/null)
```
On **FreeBSD**, base `libarchive` ships **no `.pc` file** and `curl` lives under `/usr/local`, so `pkg-config` finds nothing — and the `2>/dev/null` **silently hides the failure**, expanding the flags to an empty string. The `curl_*`/`archive_*` symbols are then undefined at link time (FreeBSD's linker is strict about this). Arch/Debian/OpenBSD ship the `.pc` files, so they passed.

## Fix
- **`.github/workflows/build.yml`**: FreeBSD VM `14.3` → `14.4`; add `curl` to the `prepare` step (`libarchive` is in base).
- **`CreateLiveMediaAssistant/GNUmakefile`**: keep `pkg-config` as the preferred path, but **fall back** to explicit `-I/usr/local/include -L/usr/local/lib -lcurl -larchive` whenever it yields nothing — matching the existing `BhyveAssistant`/`LoginWindow` convention. Linux/OpenBSD behaviour is unchanged.

## Result
All four jobs (FreeBSD / Arch / Debian / OpenBSD) build the `curl`+`libarchive` streaming backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)