### PR TITLE
NetworkBrowser: link libdns_sd from /usr/lib/system on NextBSD

### DIFF
--- a/NetworkBrowser/GNUmakefile
+++ b/NetworkBrowser/GNUmakefile
@@ -78,6 +78,16 @@ endif
 
 ifeq ($(HAVE_DNS_SD_HEADER),yes)
   ifeq ($(HAVE_DNS_SD_LIB),yes)
+    # NextBSD ships the base mDNSResponder client library as
+    # /usr/lib/system/libdns_sd.so. That directory is on Gershwin binaries'
+    # runtime RUNPATH but is NOT a default link-time search dir, so name the
+    # -L explicitly here. Gated on that exact base file existing, so Linux
+    # (/usr/lib, default path) and FreeBSD ports (/usr/local/lib) — where this
+    # file is absent — are completely unaffected.
+    ifneq ($(wildcard /usr/lib/system/libdns_sd.so),)
+      NetworkBrowser_GUI_LIBS += -L/usr/lib/system
+      NetworkBrowserTest_GUI_LIBS += -L/usr/lib/system
+    endif
     NetworkBrowser_GUI_LIBS += -ldns_sd
     NetworkBrowserTest_GUI_LIBS += -ldns_sd
     ADDITIONAL_OBJCFLAGS += -DHAVE_DNS_SD=1


### PR DESCRIPTION
## Problem

On NextBSD, building NetworkBrowser fails at link:

```
Linking app NetworkBrowser ...
ld: error: unable to find library -ldns_sd
```

NetworkBrowser detects `libdns_sd` and appends `-ldns_sd` (line 81) but adds **no `-L` of its own** — it relied on the library's directory already being on the link path:

- **Linux** — avahi-compat's `libdns_sd` is in `/usr/lib` (a default dir) ✓
- **stock FreeBSD** — ports install to `/usr/local/lib`, which gnustep-make adds ✓
- **NextBSD** — base installs the mDNSResponder client lib as **`/usr/lib/system/libdns_sd.so`**, which is on Gershwin binaries' runtime RUNPATH (`/System/Library/Libraries:/usr/lib/system`) but is **not** a default *link-time* search dir ✗

`/usr/lib/system` was only on the link path incidentally, because the Gershwin domain's libdispatch used to live there too. Once libdispatch moved to `/System/Library/Libraries` (gershwin-developer #45), `/usr/lib/system` fell off the link line and this latent missing `-L` surfaced.

## Fix

When the base file `/usr/lib/system/libdns_sd.so` exists, add `-L/usr/lib/system`:

```make
ifneq ($(wildcard /usr/lib/system/libdns_sd.so),)
  NetworkBrowser_GUI_LIBS += -L/usr/lib/system
  NetworkBrowserTest_GUI_LIBS += -L/usr/lib/system
endif
```

The gate is that **exact** base path, so **Linux** (`/usr/lib`) and **FreeBSD ports** (`/usr/local/lib`) — where the file is absent — are byte-for-byte unaffected. Runtime resolution is already covered by the existing RUNPATH.

Verified the conditional resolves to `-ldns_sd` alone when the file is absent and `-L/usr/lib/system -ldns_sd` when present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)