### PR TITLE
Link libcurl in NetworkBackend; stop masking Menu build/install failures

### DIFF
--- a/Assistants/AssistantFramework/GNUmakefile
+++ b/Assistants/AssistantFramework/GNUmakefile
@@ -65,14 +65,22 @@ after-install::
 
 install:: custom-install
 
+# A framework bundle contains symlinks (Versions/Current, Resources, Headers).
+# Copying over an existing install makes cp descend into those symlinked
+# directories: GNU cp replaces the link, but BSD cp refuses with
+#   "cannot overwrite directory ... with non-directory"
+# which broke reinstalls on OpenBSD. Remove the old bundle first so the copy
+# always lands on a clean target.
 custom-install: $(FRAMEWORK_NAME).framework
 	@if [ -n "$(DESTDIR)" ]; then \
 		echo "Installing $(FRAMEWORK_NAME) to $(DESTDIR)$(FRAMEWORK_INSTALL_DIR)"; \
 		mkdir -p $(DESTDIR)$(FRAMEWORK_INSTALL_DIR); \
+		rm -rf $(DESTDIR)$(FRAMEWORK_INSTALL_DIR)/$(FRAMEWORK_NAME).framework; \
 		cp -R $(FRAMEWORK_NAME).framework $(DESTDIR)$(FRAMEWORK_INSTALL_DIR)/; \
 	else \
 		echo "Installing $(FRAMEWORK_NAME) to $(FRAMEWORK_INSTALL_DIR)"; \
 		mkdir -p $(FRAMEWORK_INSTALL_DIR); \
+		rm -rf $(FRAMEWORK_INSTALL_DIR)/$(FRAMEWORK_NAME).framework; \
 		cp -R $(FRAMEWORK_NAME).framework $(FRAMEWORK_INSTALL_DIR)/; \
 	fi
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -94,9 +94,18 @@ install:
 			$(call run_configure,$$$$d); \
 		fi; \
 		if [ -f "$${d}/Makefile" -o -f "$${d}/GNUmakefile" ]; then \
-			echo "Installing $$d"; $(MAKE) -C $$d install || true; \
+			echo "Installing $$d"; \
+			if ! $(MAKE) -C $$d install; then \
+				echo "ERROR: install failed for $$d" >&2; \
+				failed="$$failed $$d"; \
+			fi; \
 		fi; \
-	done
+	done; \
+	if [ -n "$$failed" ]; then \
+		echo "" >&2; \
+		echo "ERROR: the following components failed to install:$$failed" >&2; \
+		exit 1; \
+	fi
 
 help:
 	@echo "Top-level GNUmakefile for gershwin-components"; \

--- a/Libraries/NetworkBackend/GNUmakefile
+++ b/Libraries/NetworkBackend/GNUmakefile
@@ -18,6 +18,18 @@ libNetworkBackend_HEADER_FILES = \
 libNetworkBackend_INSTALL_HEADERS_DIR = NetworkBackend
 libNetworkBackend_FRAMEWORKS_DEPEND_UPON = AppKit Foundation
 
+# CaptivePortalDetector.m calls libcurl, so this library must link against it.
+# Without this the .so still builds -- shared objects may carry undefined
+# symbols -- but every executable that links -lNetworkBackend then fails.
+# Linux toolchains have historically tolerated this; LLD on FreeBSD/NextBSD
+# enforces --no-allow-shlib-undefined and rejects it, which is what stopped
+# Menu.app from building on the BSD ISOs.
+CURL_LIBS := $(shell pkg-config --libs libcurl 2>/dev/null || echo -lcurl)
+CURL_CFLAGS := $(shell pkg-config --cflags libcurl 2>/dev/null)
+
+libNetworkBackend_LIBRARIES_DEPEND_UPON += $(CURL_LIBS)
+ADDITIONAL_CPPFLAGS += $(CURL_CFLAGS)
+
 include $(GNUSTEP_MAKEFILES)/library.make
 
 after-install::

--- a/Menu/GNUmakefile
+++ b/Menu/GNUmakefile
@@ -183,15 +183,31 @@ INSTALL_APPS_DIR = /System/Library/CoreServices/Applications
 include $(GNUSTEP_MAKEFILES)/application.make
 
 # Build standalone .gsmenuextra bundles after main app is compiled
+# Menu extra bundles. Errors are NOT suppressed here: hiding them with
+# 2>/dev/null and reporting "skipped" turned real build failures into a
+# silently incomplete menu bar that only showed up at runtime.
+#
+# after-Menu-all runs inside the Instance-level make, which passes
+# GNUSTEP_INSTANCE down through MAKEFLAGS. Inheriting it sends the sub-make
+# down the Instance code path, where the "all" target does not exist
+# ("No rule to make target 'all'"). It arrives as a command-line override, so
+# clearing the environment is not enough -- it must be overridden on the
+# child's own command line.
+MENU_EXTRA_DIRS = \
+	StatusItems/ClockExtra \
+	StatusItems/BatteryExtra \
+	StatusItems/WLANExtra \
+	StatusItems/WLANExtra/wlanauth \
+	StatusItems/SoundExtra \
+	StatusItems/BrightnessExtra
+
 after-Menu-all::
 	@echo "Building standalone menu extra bundles..."
-	@(cd StatusItems/ClockExtra && GNUSTEP_MAKEFILES=$(GNUSTEP_MAKEFILES) $(MAKE) all 2>/dev/null || echo "  (ClockExtra skipped)")
-	@(cd StatusItems/BatteryExtra && GNUSTEP_MAKEFILES=$(GNUSTEP_MAKEFILES) $(MAKE) all 2>/dev/null || echo "  (BatteryExtra skipped)")
-	@(cd StatusItems/WLANExtra && GNUSTEP_MAKEFILES=$(GNUSTEP_MAKEFILES) $(MAKE) all 2>/dev/null || echo "  (WLANExtra skipped)")
-	@(cd StatusItems/WLANExtra/wlanauth && GNUSTEP_MAKEFILES=$(GNUSTEP_MAKEFILES) $(MAKE) all 2>/dev/null || echo "  (wlanauth skipped)")
-	@cp StatusItems/WLANExtra/wlanauth/obj/wlanauth Resources/ 2>/dev/null || true
-	@(cd StatusItems/SoundExtra && GNUSTEP_MAKEFILES=$(GNUSTEP_MAKEFILES) $(MAKE) all 2>/dev/null || echo "  (SoundExtra skipped)")
-	@(cd StatusItems/BrightnessExtra && GNUSTEP_MAKEFILES=$(GNUSTEP_MAKEFILES) $(MAKE) all 2>/dev/null || echo "  (BrightnessExtra skipped)")
+	@for d in $(MENU_EXTRA_DIRS); do \
+		echo "  Building $$d"; \
+		(cd $$d && GNUSTEP_MAKEFILES=$(GNUSTEP_MAKEFILES) $(MAKE) GNUSTEP_INSTANCE= all) || exit 1; \
+	done
+	@cp StatusItems/WLANExtra/wlanauth/obj/wlanauth Resources/
 	@echo "Done building bundles."
 
 # Custom install target that completely overrides built-in behavior
@@ -224,17 +240,17 @@ custom-install: $(APP_NAME).app
 		echo "Installing status item bundles..."; \
 		mkdir -p $(DESTDIR)/System/Library/Menu/StatusItems; \
 		mkdir -p $(DESTDIR)/System/Library/MenuExtras; \
-		cp -R StatusItems/SystemMonitor/SystemMonitor.bundle $(DESTDIR)/System/Library/Menu/StatusItems/ || true; \
-		cp -R StatusItems/ClockExtra/Clock.gsmenuextra $(DESTDIR)/System/Library/Menu/StatusItems/ || true; \
-		cp -R StatusItems/ClockExtra/Clock.gsmenuextra $(DESTDIR)/System/Library/MenuExtras/ || true; \
-		cp -R StatusItems/BatteryExtra/Battery.gsmenuextra $(DESTDIR)/System/Library/Menu/StatusItems/ || true; \
-		cp -R StatusItems/BatteryExtra/Battery.gsmenuextra $(DESTDIR)/System/Library/MenuExtras/ || true; \
-		cp -R StatusItems/WLANExtra/WLAN.gsmenuextra $(DESTDIR)/System/Library/Menu/StatusItems/ || true; \
-		cp -R StatusItems/WLANExtra/WLAN.gsmenuextra $(DESTDIR)/System/Library/MenuExtras/ || true; \
-		cp -R StatusItems/SoundExtra/Sound.gsmenuextra $(DESTDIR)/System/Library/Menu/StatusItems/ || true; \
-		cp -R StatusItems/SoundExtra/Sound.gsmenuextra $(DESTDIR)/System/Library/MenuExtras/ || true; \
-		cp -R StatusItems/BrightnessExtra/Brightness.gsmenuextra $(DESTDIR)/System/Library/Menu/StatusItems/ || true; \
-		cp -R StatusItems/BrightnessExtra/Brightness.gsmenuextra $(DESTDIR)/System/Library/MenuExtras/ || true; \
+		cp -R StatusItems/SystemMonitor/SystemMonitor.bundle $(DESTDIR)/System/Library/Menu/StatusItems/; \
+		cp -R StatusItems/ClockExtra/Clock.gsmenuextra $(DESTDIR)/System/Library/Menu/StatusItems/; \
+		cp -R StatusItems/ClockExtra/Clock.gsmenuextra $(DESTDIR)/System/Library/MenuExtras/; \
+		cp -R StatusItems/BatteryExtra/Battery.gsmenuextra $(DESTDIR)/System/Library/Menu/StatusItems/; \
+		cp -R StatusItems/BatteryExtra/Battery.gsmenuextra $(DESTDIR)/System/Library/MenuExtras/; \
+		cp -R StatusItems/WLANExtra/WLAN.gsmenuextra $(DESTDIR)/System/Library/Menu/StatusItems/; \
+		cp -R StatusItems/WLANExtra/WLAN.gsmenuextra $(DESTDIR)/System/Library/MenuExtras/; \
+		cp -R StatusItems/SoundExtra/Sound.gsmenuextra $(DESTDIR)/System/Library/Menu/StatusItems/; \
+		cp -R StatusItems/SoundExtra/Sound.gsmenuextra $(DESTDIR)/System/Library/MenuExtras/; \
+		cp -R StatusItems/BrightnessExtra/Brightness.gsmenuextra $(DESTDIR)/System/Library/Menu/StatusItems/; \
+		cp -R StatusItems/BrightnessExtra/Brightness.gsmenuextra $(DESTDIR)/System/Library/MenuExtras/; \
 	else \
 		echo "Installing $(APP_NAME) to $(INSTALL_APPS_DIR)"; \
 		rm -rf /System/Applications/$(APP_NAME).app || true; \
@@ -243,19 +259,20 @@ custom-install: $(APP_NAME).app
 		mkdir -p $(INSTALL_APPS_DIR)/$(APP_NAME).app/Resources; \
 		cp Menu.png $(INSTALL_APPS_DIR)/$(APP_NAME).app/Resources/; \
 			echo "Installing status item bundles..."; \
+			mkdir -p /System/Library/Menu/StatusItems; \
 			mkdir -p /System/Library/MenuExtras; \
 			mkdir -p /Local/Library/MenuExtras; \
-			cp -R StatusItems/SystemMonitor/SystemMonitor.bundle /System/Library/Menu/StatusItems/ || true; \
-			cp -R StatusItems/ClockExtra/Clock.gsmenuextra /System/Library/Menu/StatusItems/ || true; \
-			cp -R StatusItems/ClockExtra/Clock.gsmenuextra /System/Library/MenuExtras/ || true; \
-			cp -R StatusItems/BatteryExtra/Battery.gsmenuextra /System/Library/Menu/StatusItems/ || true; \
-			cp -R StatusItems/BatteryExtra/Battery.gsmenuextra /System/Library/MenuExtras/ || true; \
-			cp -R StatusItems/WLANExtra/WLAN.gsmenuextra /System/Library/Menu/StatusItems/ || true; \
-			cp -R StatusItems/WLANExtra/WLAN.gsmenuextra /System/Library/MenuExtras/ || true; \
-			cp -R StatusItems/SoundExtra/Sound.gsmenuextra /System/Library/Menu/StatusItems/ || true; \
-			cp -R StatusItems/SoundExtra/Sound.gsmenuextra /System/Library/MenuExtras/ || true; \
-			cp -R StatusItems/BrightnessExtra/Brightness.gsmenuextra /System/Library/Menu/StatusItems/ || true; \
-			cp -R StatusItems/BrightnessExtra/Brightness.gsmenuextra /System/Library/MenuExtras/ || true; \
+			cp -R StatusItems/SystemMonitor/SystemMonitor.bundle /System/Library/Menu/StatusItems/; \
+			cp -R StatusItems/ClockExtra/Clock.gsmenuextra /System/Library/Menu/StatusItems/; \
+			cp -R StatusItems/ClockExtra/Clock.gsmenuextra /System/Library/MenuExtras/; \
+			cp -R StatusItems/BatteryExtra/Battery.gsmenuextra /System/Library/Menu/StatusItems/; \
+			cp -R StatusItems/BatteryExtra/Battery.gsmenuextra /System/Library/MenuExtras/; \
+			cp -R StatusItems/WLANExtra/WLAN.gsmenuextra /System/Library/Menu/StatusItems/; \
+			cp -R StatusItems/WLANExtra/WLAN.gsmenuextra /System/Library/MenuExtras/; \
+			cp -R StatusItems/SoundExtra/Sound.gsmenuextra /System/Library/Menu/StatusItems/; \
+			cp -R StatusItems/SoundExtra/Sound.gsmenuextra /System/Library/MenuExtras/; \
+			cp -R StatusItems/BrightnessExtra/Brightness.gsmenuextra /System/Library/Menu/StatusItems/; \
+			cp -R StatusItems/BrightnessExtra/Brightness.gsmenuextra /System/Library/MenuExtras/; \
 	fi
 # Override uninstall target to properly support DESTDIR and PREFIX
 uninstall:: custom-uninstall

--- a/PackageManager/OnDemand/GNUmakefile
+++ b/PackageManager/OnDemand/GNUmakefile
@@ -57,8 +57,17 @@ $(APP_NAME).app/Resources/Install.plist: Resources/Install.plist
 
 all:: $(APP_NAME).app/Resources/Info.plist $(APP_NAME).app/Resources/Install.plist
 
+# Do not invoke sudo unconditionally. Image builds and CI run as root, and a
+# stock FreeBSD/OpenBSD install has no sudo at all, so this failed with
+# "sudo: No such file or directory" (exit 127). Use it only when we are not
+# root and it is actually available.
+SUDO := $(shell if [ "$$(id -u)" = "0" ]; then echo ""; \
+	elif command -v sudo >/dev/null 2>&1; then echo "sudo"; \
+	else echo ""; fi)
+
 system-install: $(APP_NAME).app
-	sudo mkdir -p /System/Library/Services
-	sudo cp -R $(APP_NAME).app /System/Library/Services/
-	sudo chmod -R a+rX /System/Library/Services/$(APP_NAME).app
+	$(SUDO) mkdir -p /System/Library/Services
+	$(SUDO) rm -rf /System/Library/Services/$(APP_NAME).app
+	$(SUDO) cp -R $(APP_NAME).app /System/Library/Services/
+	$(SUDO) chmod -R a+rX /System/Library/Services/$(APP_NAME).app
 	@echo "Installed $(APP_NAME).app to /System/Library/Services/"

--- a/PackageManager/Placeholders/GNUmakefile
+++ b/PackageManager/Placeholders/GNUmakefile
@@ -31,6 +31,14 @@ clean::
 	done
 endef
 
+# Do not invoke sudo unconditionally. Image builds and CI run as root, and a
+# stock FreeBSD/OpenBSD install has no sudo at all, so this died with
+# "sudo: not found" (exit 127). Empty when already root or when sudo is
+# missing; otherwise "sudo". Mirrors the guard in OnDemand/GNUmakefile.
+SUDO := $(shell if [ "$$(id -u)" = "0" ]; then echo ""; \
+	elif command -v sudo >/dev/null 2>&1; then echo "sudo"; \
+	else echo ""; fi)
+
 # Install template
 define make-install
 .PHONY: install-$(1)
@@ -40,9 +48,9 @@ install-$(1): $(1)
 	  dname=$$$$(echo "$$$$app" | tr '_' ' '); \
 	  bdir="$$$$cat/$$$$app.app"; \
 	  instdir="/System/Applications/$$$$cat/$$$$dname.app"; \
-	  sudo mkdir -p "$$$$instdir/Resources"; \
-	  sudo cp "$$$$bdir/Resources/"* "$$$$instdir/Resources/"; \
-	  sudo ln -sf /System/Library/Services/OnDemand.app/OnDemand "$$$$instdir/$$$$dname"; \
+	  $(SUDO) mkdir -p "$$$$instdir/Resources"; \
+	  $(SUDO) cp "$$$$bdir/Resources/"* "$$$$instdir/Resources/"; \
+	  $(SUDO) ln -sf /System/Library/Services/OnDemand.app/OnDemand "$$$$instdir/$$$$dname"; \
 	done
 endef
 

--- a/Whisper/GNUmakefile
+++ b/Whisper/GNUmakefile
@@ -12,6 +12,42 @@ include $(GNUSTEP_MAKEFILES)/common.make
 
 GNUSTEP_INSTALLATION_DOMAIN = SYSTEM
 
+#
+# Whisper needs the whisper.cpp headers and libwhisper. None of the
+# gershwin-developer requirement lists (Library/OSSupport/*.txt) provision it,
+# so on a stock checkout -- CI included -- it is simply not present, and the
+# component cannot be built at all.
+#
+# Probe for the header and skip this component with a clear message when it is
+# missing, rather than failing the whole tree. This is an explicit, reported
+# skip: it prints why it is skipping. That is deliberately different from
+# swallowing the error with "|| true", which is what previously let this
+# failure hide inside a green build.
+#
+WHISPER_PROBE_CFLAGS := -I/usr/local/include $(shell pkg-config --cflags whisper 2>/dev/null)
+
+WHISPER_CC := $(CC)
+ifeq ($(strip $(WHISPER_CC)),)
+WHISPER_CC := $(shell command -v clang 2>/dev/null || command -v cc 2>/dev/null || command -v gcc 2>/dev/null)
+endif
+
+ifneq ($(strip $(WHISPER_CC)),)
+WHISPER_AVAILABLE := $(shell printf '#include <whisper.h>\n' | \
+	$(WHISPER_CC) $(WHISPER_PROBE_CFLAGS) -x c -E - >/dev/null 2>&1 && echo yes)
+endif
+
+ifneq ($(WHISPER_AVAILABLE),yes)
+
+.PHONY: all build install clean distclean check
+
+all build install clean distclean check:
+	@echo "Whisper: SKIPPED -- whisper.h not found (whisper.cpp / libwhisper)."
+	@echo "Whisper: install whisper.cpp, or add it to"
+	@echo "Whisper:   gershwin-developer/Library/OSSupport/<os>.txt,"
+	@echo "Whisper: then re-run to build this component."
+
+else
+
 APP_NAME = Whisper
 PACKAGE_NAME = Whisper
 Whisper_PRINCIPAL_CLASS = NSApplication
@@ -45,7 +81,11 @@ Whisper_C_FILES = \
 	WAudioLoader.c \
 	WCapture.c
 
-ADDITIONAL_INCLUDE_DIRS += -I/usr/local/include -I/Developer/Library/Sources/gershwin-components/Sound
+# Sound headers (ALSABackend.h / OSSBackend.h) come from the sibling Sound
+# directory. This must stay relative: an absolute /Developer/Library/Sources
+# path only resolves on an installed Gershwin system, so CI and any checkout
+# elsewhere failed with "'ALSABackend.h' file not found". Matches Menu's -I../Sound.
+ADDITIONAL_INCLUDE_DIRS += -I/usr/local/include -I../Sound
 
 #
 # Link libraries
@@ -72,3 +112,5 @@ $(APP_DIR)/Resources/$(GNUSTEP_INSTANCE).desktop:
 	$(ECHO_NOTHING)touch $(APP_DIR)/Resources/$(GNUSTEP_INSTANCE).desktop; chmod a+x $(APP_DIR)/Resources/$(GNUSTEP_INSTANCE).desktop$(END_ECHO)
 
 -include GNUmakefile.postamble
+
+endif


### PR DESCRIPTION
Menu.app has been missing from NextBSD/FreeBSD dev-branch ISOs while working on Linux. There turned out to be three separate defects, each hidden by the next.

## 1. `Libraries/NetworkBackend` did not link libcurl

`CaptivePortalDetector.m` calls `curl_easy_init/setopt/perform/getinfo/cleanup`, but the GNUmakefile never linked `-lcurl`, so `libNetworkBackend.so` shipped with those symbols undefined:

```
nm -D --undefined-only libNetworkBackend.so | grep curl
    U curl_easy_cleanup / getinfo / init / perform / setopt

ldd libNetworkBackend.so
    libgcc_s, libthr, libc, libsys      <- no libcurl
```

A shared object is allowed to carry undefined symbols, so this was **latent on every platform**. It only becomes fatal when an *executable* links against it, and LLD on FreeBSD/NextBSD enforces `--no-allow-shlib-undefined`. `Menu` links `-lNetworkBackend`, so Menu is what died:

```
ld: error: undefined reference: curl_easy_init
>>> referenced by libNetworkBackend.so (disallowed by --no-allow-shlib-undefined)
```

That is the whole Linux/BSD split — same missing dependency, different linker strictness.

Fixed by linking through `pkg-config` with a plain `-lcurl` fallback.

## 2. Menu extra bundles never built from `after-Menu-all`

`after-Menu-all` runs inside the Instance-level make, which passes `GNUSTEP_INSTANCE` down through `MAKEFLAGS`. The sub-make then took the Instance code path, where `all` does not exist:

```
gmake[3]: *** No rule to make target 'all'.  Stop.
```

Because it arrives as a **command-line override**, clearing the environment (`env -u GNUSTEP_INSTANCE`) does not help — it has to be overridden on the child's own command line. Confirmed both directions:

```
MAKEFLAGS='GNUSTEP_INSTANCE=Menu' gmake all                    -> No rule to make target 'all'
MAKEFLAGS='GNUSTEP_INSTANCE=Menu' gmake GNUSTEP_INSTANCE= all  -> builds
```

Every bundle built correctly standalone, which is why this went unnoticed — and `2>/dev/null || echo "  (X skipped)"` hid the error completely.

## 3. `custom-install` never created `/System/Library/Menu/StatusItems`

The `DESTDIR` branch creates that directory; the non-`DESTDIR` branch did not, so `SystemMonitor.bundle` (the CPU/RAM indicators) silently failed to install:

```
cp: /System/Library/Menu/StatusItems: No such file or directory
```

## Stop masking failures

These bugs were individually small. What turned them into a silently missing menu bar across every BSD ISO was the error suppression around them:

- Top-level `install` no longer uses `|| true` per component. It records failures, reports each one, and exits non-zero with a summary at the end.
- Menu's bundle build and install steps no longer discard stderr or ignore copy failures.

`|| true` occurrences in `Menu/GNUmakefile` drop from 26 to 4 — the remaining ones are harmless `rm -rf` and stale-header cleanup.

## Verification

Built, installed and rebooted on NextBSD 15.1 (FreeBSD 15.1-RELEASE-p1) at 3840x2160. Menu.app runs, and all extras are present in the bar — Clock, Sound, WLAN, and SystemMonitor's CPU/RAM readouts:

(Screenshot available on request.)

```
admin  244  0.1  S  Menu
admin  231  0.0  S  WindowManager

/System/Library/Menu/StatusItems/
    Battery.gsmenuextra  Brightness.gsmenuextra  Clock.gsmenuextra
    Sound.gsmenuextra    WLAN.gsmenuextra        SystemMonitor.bundle

ldd Menu | grep -E 'curl|NetworkBackend'
    libNetworkBackend.so.1 => /System/Library/Libraries/libNetworkBackend.so.1
    libcurl.so.4           => /usr/local/lib/libcurl.so.4
```

The WindowManager fix in gershwin-windowmanager#69 is also applied on this machine, which is why the desktop renders at 4K here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Whisper (surfaced by removing the masking)

Dropping `|| true` immediately exposed a pre-existing failure that CI had been reporting as success. The last green `dev` run ([29877516599](https://github.com/gershwin-desktop/gershwin-components/actions/runs/29877516599)) contains the identical error in its Debian log:

```
WhisperController.m:11:9: fatal error: 'ALSABackend.h' file not found
```

Two problems, both fixed here:

1. **Hardcoded absolute include path.** `-I/Developer/Library/Sources/gershwin-components/Sound` only resolves on an installed Gershwin system. CI symlinks the checkout into `gershwin-developer/Library/Sources/gershwin-components`, so the include pointed at nothing. Now `-I../Sound`, matching Menu. This was the only hardcoded `/Developer` path in any makefile in the tree.

2. **libwhisper is not provisioned anywhere.** No `gershwin-developer/Library/OSSupport/*.txt` list includes whisper.cpp, so `whisper.h` is absent on any stock checkout including CI — fixing the include path alone just moves the failure one line down. Whisper now probes for the header and, when absent, defines stub targets that print why it is skipping and exit 0.

That skip is deliberately loud — it states the reason and how to enable the component. It is not a return to `|| true`: the goal of removing that was to stop failures being *invisible*, and this one announces itself. An optional component whose dependency is not packaged on any supported platform should not fail the entire tree.

If you would rather Whisper build in CI, the alternative is adding whisper.cpp to the OSSupport lists — though it does not appear to be packaged for Debian, which is presumably how it ended up in this state.